### PR TITLE
2015 04 15 plugins release and move to npm

### DIFF
--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -206,7 +206,7 @@ cordova-plugin-file@2.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * docs: added **Windows** to supported platforms
-* [CB-8699](https://issues.apache.org/jira/browse/CB-8699) [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Fix uncompressed assets being copied as zero length files
+* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Fix uncompressed assets being copied as zero length files
 * [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android**: Fix assets `FileEntry` having size of -1
 * **Android**: Move `URLforFullPath` into base class (and rename to `localUrlforFullPath`)
 * [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Mention `build-extras.gradle` in README

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -401,3 +401,7 @@ cordova-plugin-vibration@1.0.0
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Add `cordova-plugin-vibration` support for **Windows Phone 8.1**
 * [CB-8576](https://issues.apache.org/jira/browse/CB-8576) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
+
+[npm]: https://www.npmjs.org/
+[CPR]: http://plugins.cordova.io
+[ecosystem:cordova]: https://www.npmjs.com/search?q=ecosystem%3Acordova

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -104,7 +104,7 @@ cordova-plugin-battery-status@1.0.0
 
 cordova-plugin-camera@1.0.0
 
-* [CB-8780](https://issues.apache.org/jira/browse/CB-8780) Display popover using main thread. Fixes popover slowness (closes #81)
+* [CB-8780](https://issues.apache.org/jira/browse/CB-8780) Display popover using main thread. Fixes popover slowness
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
 * [CB-8707](https://issues.apache.org/jira/browse/CB-8707) refactoring **Windows** code to improve readability
 * [CB-8706](https://issues.apache.org/jira/browse/CB-8706) use `filePicker` if `saveToPhotoAlbum` is true
@@ -117,7 +117,7 @@ cordova-plugin-camera@1.0.0
 * [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Partial fix for Save Image to Gallery error found in `MobileSpec`
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* [CB-8351](https://issues.apache.org/jira/browse/CB-8351) Fix custom implementation of `integerValueForKey` (close #79)
+* [CB-8351](https://issues.apache.org/jira/browse/CB-8351) Fix custom implementation of `integerValueForKey`
 * Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install **paramedic**
 * docs: added **Windows** to supported platforms
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
@@ -210,8 +210,8 @@ cordova-plugin-file@2.0.0
 * [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android**: Fix assets `FileEntry` having size of -1
 * **Android**: Move `URLforFullPath` into base class (and rename to `localUrlforFullPath`)
 * [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Mention `build-extras.gradle` in README
-* [CB-7109](https://issues.apache.org/jira/browse/CB-7109) **Android**: Parse arguments off of the main thread (close #97)
-* [CB-8695](https://issues.apache.org/jira/browse/CB-8695) **iOS**: Fix `blob.slice()` for `asset-library` URLs (close #105)
+* [CB-7109](https://issues.apache.org/jira/browse/CB-7109) **Android**: Parse arguments off of the main thread
+* [CB-8695](https://issues.apache.org/jira/browse/CB-8695) **iOS**: Fix `blob.slice()` for `asset-library` URLs
 * Tweak build-extras.gradle to just read/write to main `assets/` instead of `build/`
 * [CB-8689](https://issues.apache.org/jira/browse/CB-8689) Fix `NPE` in `makeEntryForNativeUri` (was affecting file-transfer)
 * [CB-8675](https://issues.apache.org/jira/browse/CB-8675) Revert "CB-8351 ios: Use `base64EncodedStringWithOptions` instead of `CordovaLib's` class extension"
@@ -231,7 +231,7 @@ cordova-plugin-file@2.0.0
 * **Android**: Use Uri.parse rather than manual parsing in resolveLocalFileSystemURI
 * **Android**: Delete invalid `JavaDoc` (lint errors)
 * **Android**: Use `CordovaResourceAp`i rather than `FileHelper`
-* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) File Plugin - Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:` (closes #96)
+* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) File Plugin - Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:`
 * [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-7956](https://issues.apache.org/jira/browse/CB-7956) Add `cordova-plugin-file` support for **Browser** platform
@@ -302,7 +302,7 @@ cordova-plugin-inappbrowser@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8432](https://issues.apache.org/jira/browse/CB-8432) Correct styles for **Browser** wrapper to display it correctly on some pages
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x (closes #93)
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x
 * [CB-7961](https://issues.apache.org/jira/browse/CB-7961) Add `cordova-plugin-inappbrowser` support for **Browser** platform
 * Update docs for **Android** `zoom=no` option
 * Added option to disable/enable zoom controls
@@ -310,8 +310,8 @@ cordova-plugin-inappbrowser@1.0.0
 * Add a `hardwareback` option to allow for the hardware back button to go back
 * [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* Keep external **Android** pages in a single tab. (close #61)
-* [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Add a clobber for `cordova.InAppBrowser.open` (close #80)
+* Keep external **Android** pages in a single tab.
+* [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Add a clobber for `cordova.InAppBrowser.open`
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Don't clobber `window.open` - Add new symbol/clobber to access open function (`cordova.InAppBrowser.open`) Change existing tests to use new symbol (i.e. don't rely on plugin clobber of `window.open`) - Add tests to use `window.open` via manual replace with new symbol - Update docs to deprecate plugin clobber of `window.open`
 
 cordova-plugin-media@1.0.0
@@ -363,7 +363,7 @@ cordova-plugin-splashscreen@2.0.0
 * [CB-8797](https://issues.apache.org/jira/browse/CB-8797) Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen` (**iOS**) are missing
 * [CB-8836](https://issues.apache.org/jira/browse/CB-8836) Crashes after animating `splashscreen`
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Fix missing import in previous commit
-* [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Adds `SplashMaintainAspectRatio` preference (close #43)
+* [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Adds `SplashMaintainAspectRatio` preference
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -391,7 +391,7 @@ cordova-plugin-test-framework@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Add a shim for `jasmine.Expectation.addMatchers` being moved in **jasmine 2.2.0**
-* [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Update test framework plugin to use **Jasmine 2.2.0** (close #11)
+* [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Update test framework plugin to use **Jasmine 2.2.0**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8385](https://issues.apache.org/jira/browse/CB-8385) Ensure `plugin-test-framework` trigger tests only once
 

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -381,8 +381,8 @@ cordova-plugin-statusbar@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
-* - Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme
-* - Add support for `StatusBar.backgroundColorByHexString` (and `StatusBar.backgroundColorByName`) on **Android 5** and up
+* Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme
+* Add support for `StatusBar.backgroundColorByHexString` (and `StatusBar.backgroundColorByName`) on **Android 5** and up
 * Allow setting the `statusbar backgroundcolor` on **Android**
 * [CB-8575](https://issues.apache.org/jira/browse/CB-8575) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -26,27 +26,27 @@ To find plugins on **npm**, search for [ecosystem:cordova](https://www.npmjs.com
 ----
 The following plugins were updated today:
 
-cordova-plugin-battery-status@1.0.0
-cordova-plugin-camera@1.0.0
-cordova-plugin-console@1.0.0
-cordova-plugin-contacts@1.0.0
-cordova-plugin-device@1.0.0
-cordova-plugin-device-motion@1.0.0
-cordova-plugin-device-orientation@1.0.0
-cordova-plugin-dialogs@1.0.0
-cordova-plugin-file@2.0.0
-cordova-plugin-file-transfer@1.0.0
-cordova-plugin-geolocation@1.0.0
-cordova-plugin-globalization@1.0.0
-cordova-plugin-inappbrowser@1.0.0
-cordova-plugin-legacy-whitelist@1.0.1
-cordova-plugin-media@1.0.0
-cordova-plugin-media-capture@1.0.0
-cordova-plugin-network-information@1.0.0
-cordova-plugin-splashscreen@2.0.0
-cordova-plugin-statusbar@1.0.0
-cordova-plugin-test-framework@1.0.0
-cordova-plugin-vibration@1.0.0
+* cordova-plugin-battery-status@1.0.0
+* cordova-plugin-camera@1.0.0
+* cordova-plugin-console@1.0.0
+* cordova-plugin-contacts@1.0.0
+* cordova-plugin-device@1.0.0
+* cordova-plugin-device-motion@1.0.0
+* cordova-plugin-device-orientation@1.0.0
+* cordova-plugin-dialogs@1.0.0
+* cordova-plugin-file@2.0.0
+* cordova-plugin-file-transfer@1.0.0
+* cordova-plugin-geolocation@1.0.0
+* cordova-plugin-globalization@1.0.0
+* cordova-plugin-inappbrowser@1.0.0
+* cordova-plugin-legacy-whitelist@1.0.1
+* cordova-plugin-media@1.0.0
+* cordova-plugin-media-capture@1.0.0
+* cordova-plugin-network-information@1.0.0
+* cordova-plugin-splashscreen@2.0.0
+* cordova-plugin-statusbar@1.0.0
+* cordova-plugin-test-framework@1.0.0
+* cordova-plugin-vibration@1.0.0
 
 ----
 To update your existing plugins, you need to update your version of `Cordova CLI` to version 5.0.0.

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -34,7 +34,7 @@ We encourage all third party plugin developers to add `ecosystem:cordova` as a k
     1. Send a pull request adding your new id and old id to [Cordova Registry Mapper](https://github.com/stevengill/cordova-registry-mapper).
     1. We integrate that module into the **Cordova CLI** to warn users to use the new `id` when adding plugins to their projects.
 
-2. Add a `package.json` to your plugins,
+1. Add a `package.json` to your plugins,
 	* **Note** To keep things simple, please make sure your `id` in `plugin.xml` is the same as your `package-name` in `package.json`.
     * Use `plugman createpackagejson [PLUGIN DIRECTORY]` to create `package.json`.
         * This will create defaults based on existing values in your `plugin.xml`.
@@ -43,7 +43,7 @@ We encourage all third party plugin developers to add `ecosystem:cordova` as a k
     * View the `package.json` of [cordova-plugin-device](https://github.com/apache/cordova-plugin-device/blob/master/package.json) to see an example of what your `package.json` should look like after running `plugman createpackagejson [PLUGIN DIRECTORY]` command.
 	* Plugins still require a `plugin.xml` to be installed into **Cordova** projects.
 
-3. Publish your plugin to **npm** using the `npm publish [PLUGIN DIRECTORY]`.
+1. Publish your plugin to **npm** using the `npm publish [PLUGIN DIRECTORY]`.
 
 ----
 The following plugins were updated today:

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -95,7 +95,7 @@ cordova-plugin-battery-status@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
-* add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery.
+* add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659): `iOS`: 4.0.x Compatibility: Remove use of `initWithWebView` method
 * added apache/travis badge - will not show until INFRA updates the github integration
@@ -307,7 +307,7 @@ cordova-plugin-inappbrowser@1.0.0
 * Update docs for **Android** `zoom=no` option
 * Added option to disable/enable zoom controls
 * updated docs, set `hardwareback` default to true
-* Add a `hardwareback` option to allow for the hardware back button to go back.
+* Add a `hardwareback` option to allow for the hardware back button to go back
 * [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * Keep external **Android** pages in a single tab. (close #61)
@@ -381,7 +381,7 @@ cordova-plugin-statusbar@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
-* - Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme.
+* - Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme
 * - Add support for `StatusBar.backgroundColorByHexString` (and `StatusBar.backgroundColorByName`) on **Android 5** and up
 * Allow setting the `statusbar backgroundcolor` on **Android**
 * [CB-8575](https://issues.apache.org/jira/browse/CB-8575) Integrate `TravisCI`

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -19,7 +19,7 @@ To find plugins on **npm**, search for [ecosystem:cordova]. We are working with 
 ## Plugin Authors: Steps to move your plugin to **npm**
 1. **Optional** Decide if you want to change your plugin's `id`. If you decide to change it, update the `id` in `plugin.xml` and update your readme with the new `id`. Next, send a pull request adding your new id and old id to [Cordova Registry Mapper](https://github.com/stevengill/cordova-registry-mapper). We integrate that module into the **Cordova CLI** to warn users to use the new `id` when adding plugins to their projects.
 
-2. Add a `package.json` to your plugins using `plugman createpackagejson [PLUGIN DIRECTORY]`. This will create defaults based on existing values in your `plugin.xml`. It will also automatically add the keyword `ecosystem:cordova` to your newly generated `package.json` file. In addition, a **cordova** key will be added to your `package.json` which we plan to use in future updates of the tooling. View the `package.json` of [cordova-plugin-device](https://github.com/apache/cordova-plugin-device/blob/master/package.json) to see an example of what your `package.json` should look like after running `plugman createpackagejson [PLUGIN DIRECTORY] command. Plugins still require a `plugin.xml` to be installed into **Cordova** projects. **Note** To keep things simple, please make sure your `id` in `plugin.xml` is the same as your `package-name` in `package.json`. 
+2. Add a `package.json` to your plugins using `plugman createpackagejson [PLUGIN DIRECTORY]`. This will create defaults based on existing values in your `plugin.xml`. It will also automatically add the keyword `ecosystem:cordova` to your newly generated `package.json` file. In addition, a **cordova** key will be added to your `package.json` which we plan to use in future updates of the tooling. View the `package.json` of [cordova-plugin-device] to see an example of what your `package.json` should look like after running `plugman createpackagejson [PLUGIN DIRECTORY] command. Plugins still require a `plugin.xml` to be installed into **Cordova** projects. **Note** To keep things simple, please make sure your `id` in `plugin.xml` is the same as your `package-name` in `package.json`.
 
 3. Publish your plugin to **npm** using the `npm publish [PLUGIN DIRECTORY]`
 
@@ -405,3 +405,4 @@ cordova-plugin-vibration@1.0.0
 [npm]: https://www.npmjs.org/
 [CPR]: http://plugins.cordova.io
 [ecosystem:cordova]: https://www.npmjs.com/search?q=ecosystem%3Acordova
+[cordova-plugin-device]: https://github.com/apache/cordova-plugin-device/blob/master/package.json

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -97,7 +97,7 @@ cordova-plugin-battery-status@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): `iOS`: 4.0.x Compatibility: Remove use of `initWithWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) `iOS`: 4.0.x Compatibility: Remove use of `initWithWebView` method
 * added apache/travis badge - will not show until INFRA updates the github integration
 * add `travis.yml` for CI with paramedic
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -111,17 +111,17 @@ cordova-plugin-camera@1.0.0
 * [CB-8706](https://issues.apache.org/jira/browse/CB-8706) remove unnecessary capabilities from `xml`
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Blackberry** specific references of `org.apache.cordova.camera` to `cordova-plugin-camera`
-* [CB-8782](https://issues.apache.org/jira/browse/CB-8782): Updated the docs to talk about the `allowEdit` quirks, it's not 100% working, but better than it was
-* [CB-8782](https://issues.apache.org/jira/browse/CB-8782): Fixed the flow so that we save the cropped image and use it, not the original non-cropped.  Crop only supports G+ Photos Crop, other crops may not work, depending on the OEM
-* [CB-8740](https://issues.apache.org/jira/browse/CB-8740): Removing `FileHelper` call that was failing on Samsung Galaxy S3, now that we have a real path, we only need to update the `MediaStore`, not pull from it in this case
-* [CB-8740](https://issues.apache.org/jira/browse/CB-8740): Partial fix for Save Image to Gallery error found in `MobileSpec`
+* [CB-8782](https://issues.apache.org/jira/browse/CB-8782) Updated the docs to talk about the `allowEdit` quirks, it's not 100% working, but better than it was
+* [CB-8782](https://issues.apache.org/jira/browse/CB-8782) Fixed the flow so that we save the cropped image and use it, not the original non-cropped.  Crop only supports G+ Photos Crop, other crops may not work, depending on the OEM
+* [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Removing `FileHelper` call that was failing on Samsung Galaxy S3, now that we have a real path, we only need to update the `MediaStore`, not pull from it in this case
+* [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Partial fix for Save Image to Gallery error found in `MobileSpec`
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8351](https://issues.apache.org/jira/browse/CB-8351) Fix custom implementation of `integerValueForKey` (close #79)
 * Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install paramedic
 * docs: added **Windows** to supported platforms
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 
 cordova-plugin-console@1.0.0
 
@@ -139,8 +139,8 @@ cordova-plugin-contacts@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * [CB-8604](https://issues.apache.org/jira/browse/CB-8604) Pended unsupported test for **wp8**, updated documentation
 * [CB-8561](https://issues.apache.org/jira/browse/CB-8561) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -176,8 +176,8 @@ cordova-plugin-device-orientation@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * force async callbacks
 * Updated plugin to be **Windows** instead of **Windows8**
 * [CB-8614](https://issues.apache.org/jira/browse/CB-8614) Fixed `getCurrentHeading` and `watchHeading` on **Windows** platform
@@ -192,7 +192,7 @@ cordova-plugin-dialogs@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8367](https://issues.apache.org/jira/browse/CB-8367) [org.apache.cordova.dialogs] Add Prompt support on **Windows**
@@ -215,7 +215,7 @@ cordova-plugin-file@2.0.0
 * Tweak build-extras.gradle to just read/write to main `assets/` instead of `build/`
 * [CB-8689](https://issues.apache.org/jira/browse/CB-8689) Fix `NPE` in `makeEntryForNativeUri` (was affecting file-transfer)
 * [CB-8675](https://issues.apache.org/jira/browse/CB-8675) Revert "CB-8351 ios: Use `base64EncodedStringWithOptions` instead of `CordovaLib's` class extension"
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
 * Add a cache to speed up `AssetFilesystem` directory listings
 * [CB-8663](https://issues.apache.org/jira/browse/CB-8663) **Android**: Don't notify `MediaScanner` of private files
 * Don't log stacktrace for normal exceptions (e.g. file not found)
@@ -271,8 +271,8 @@ cordova-plugin-geolocation@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * [CB-8681](https://issues.apache.org/jira/browse/CB-8681) Fixed occasional test failures
 * docs: added **Windows** to supported platforms
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * Wrong parameter in **Firefox OS** plugin
 * [CB-8568](https://issues.apache.org/jira/browse/CB-8568) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -286,7 +286,7 @@ cordova-plugin-globalization@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * separate section in `plugin.xml` and docs for **Windows8** platform
 * [CB-7960](https://issues.apache.org/jira/browse/CB-7960) Add `cordova-plugin-globalization` support for **Browser** platform
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
 * [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8394](https://issues.apache.org/jira/browse/CB-8394) pended unsupported tests for **Windows** and **wp8**
@@ -326,7 +326,7 @@ cordova-plugin-media@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * [CB-8686](https://issues.apache.org/jira/browse/CB-8686) - remove `musicLibrary` capability
 * [CB-7962](https://issues.apache.org/jira/browse/CB-7962) Adds **Browser** platform support
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix tests on **Windows** if no audio playback hardware is available
@@ -343,7 +343,7 @@ cordova-plugin-media-capture@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * [CB-8687](https://issues.apache.org/jira/browse/CB-8687) consolidate manifest targets
 * [CB-7963](https://issues.apache.org/jira/browse/CB-7963) Adds support for **Browser** platform
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
 * [CB-8571](https://issues.apache.org/jira/browse/CB-8571) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
@@ -354,7 +354,7 @@ cordova-plugin-network-information@1.0.0
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Fixes typo in `cordova.platformId`
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Use `navigator.onLine` as connection information source on **Browser** platform
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
 * [CB-8573](https://issues.apache.org/jira/browse/CB-8573) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -242,7 +242,6 @@ cordova-plugin-file-transfer@1.0.0
 * [CB-8566](https://issues.apache.org/jira/browse/CB-8566) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8495](https://issues.apache.org/jira/browse/CB-8495) Fixed **wp8** and **wp8.1** test failures
-* [CB-7957](https://issues.apache.org/jira/browse/CB-7957) Adds support for `browser` platform
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Use File proxy to construct valid FileEntry for download success callback
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Removes excess path to native path conversion in download method
 * [CB-8429](https://issues.apache.org/jira/browse/CB-8429) Updated version and `RELEASENOTES.md` for release 0.5.0

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -97,7 +97,7 @@ cordova-plugin-battery-status@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) `iOS`: 4.0.x Compatibility: Remove use of `initWithWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWithWebView` method
 * added apache/travis badge - will not show until INFRA updates the github integration
 * add `travis.yml` for CI with paramedic
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -201,7 +201,7 @@ cordova-plugin-file@2.0.0
 
 * [CB-8849](https://issues.apache.org/jira/browse/CB-8849) Fixed `ReadAsArrayBuffer` to return `ArrayBuffer` and not Array on **WP8**
 * [CB-8819](https://issues.apache.org/jira/browse/CB-8819) Fixed FileReader's `readAsBinaryString` on **wp8**
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) `Android`: Fix broken unit tests from plugin rename
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) **Android** Fix broken unit tests from plugin rename
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -104,7 +104,7 @@ cordova-plugin-battery-status@1.0.0
 
 cordova-plugin-camera@1.0.0
 
-* [CB-8780](https://issues.apache.org/jira/browse/CB-8780) - Display popover using main thread. Fixes popover slowness (closes #81)
+* [CB-8780](https://issues.apache.org/jira/browse/CB-8780) Display popover using main thread. Fixes popover slowness (closes #81)
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
 * [CB-8707](https://issues.apache.org/jira/browse/CB-8707) refactoring **Windows** code to improve readability
 * [CB-8706](https://issues.apache.org/jira/browse/CB-8706) use `filePicker` if `saveToPhotoAlbum` is true
@@ -231,7 +231,7 @@ cordova-plugin-file@2.0.0
 * **Android**: Use Uri.parse rather than manual parsing in resolveLocalFileSystemURI
 * **Android**: Delete invalid `JavaDoc` (lint errors)
 * **Android**: Use `CordovaResourceAp`i rather than `FileHelper`
-* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) - File Plugin - Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:` (closes #96)
+* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) File Plugin - Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:` (closes #96)
 * [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate `TravisCI`
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-7956](https://issues.apache.org/jira/browse/CB-7956) Add `cordova-plugin-file` support for **Browser** platform
@@ -257,7 +257,7 @@ cordova-plugin-file-transfer@1.0.0
 * [CB-7957](https://issues.apache.org/jira/browse/CB-7957) Adds support for `browser` platform
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Use File proxy to construct valid FileEntry for download success callback
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Removes excess path to native path conversion in download method
-* [CB-8429](https://issues.apache.org/jira/browse/CB-8429) Updated version and `RELEASENOTES.md for release 0.5.0
+* [CB-8429](https://issues.apache.org/jira/browse/CB-8429) Updated version and `RELEASENOTES.md` for release 0.5.0
 * [CB-7957](https://issues.apache.org/jira/browse/CB-7957) Adds support for **Browser** platform
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Fixes JSHint and formatting issues
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Updates tests and documentation
@@ -294,7 +294,7 @@ cordova-plugin-globalization@1.0.0
 cordova-plugin-inappbrowser@1.0.0
 
 * [CB-7689](https://issues.apache.org/jira/browse/CB-7689) Adds `insertCSS` support for **Windows** platform
-* [CB-4930](https://issues.apache.org/jira/browse/CB-4930) - (prefix) InAppBrowser should take into account the status bar
+* [CB-4930](https://issues.apache.org/jira/browse/CB-4930) (prefix) InAppBrowser should take into account the status bar
 * [CB-8635](https://issues.apache.org/jira/browse/CB-8635) Improves UX on **Windows** platform
 * [CB-8661](https://issues.apache.org/jira/browse/CB-8661) Return executed script result on **Windows**
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **WP** and **Browser** specific references of old id to new id
@@ -302,7 +302,7 @@ cordova-plugin-inappbrowser@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
 * [CB-8432](https://issues.apache.org/jira/browse/CB-8432) Correct styles for **Browser** wrapper to display it correctly on some pages
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) - Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x (closes #93)
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x (closes #93)
 * [CB-7961](https://issues.apache.org/jira/browse/CB-7961) Add `cordova-plugin-inappbrowser` support for **Browser** platform
 * Update docs for **Android** `zoom=no` option
 * Added option to disable/enable zoom controls
@@ -312,7 +312,7 @@ cordova-plugin-inappbrowser@1.0.0
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * Keep external **Android** pages in a single tab. (close #61)
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Add a clobber for `cordova.InAppBrowser.open` (close #80)
-* [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Don't clobber `window.open` - Add new symbol/clobber to access open function (`cordova.InAppBrowser.open`) - Change existing tests to use new symbol (i.e. don't rely on plugin clobber of `window.open`) - Add tests to use `window.open` via manual replace with new symbol - Update docs to deprecate plugin clobber of `window.open`
+* [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Don't clobber `window.open` - Add new symbol/clobber to access open function (`cordova.InAppBrowser.open`) Change existing tests to use new symbol (i.e. don't rely on plugin clobber of `window.open`) - Add tests to use `window.open` via manual replace with new symbol - Update docs to deprecate plugin clobber of `window.open`
 
 cordova-plugin-media@1.0.0
 
@@ -324,7 +324,7 @@ cordova-plugin-media@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8541](https://issues.apache.org/jira/browse/CB-8541) Adds information about available recording formats on **Windows**
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
-* [CB-8686](https://issues.apache.org/jira/browse/CB-8686) - remove `musicLibrary` capability
+* [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
 * [CB-7962](https://issues.apache.org/jira/browse/CB-7962) Adds **Browser** platform support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate `TravisCI`
@@ -360,8 +360,8 @@ cordova-plugin-network-information@1.0.0
 
 cordova-plugin-splashscreen@2.0.0
 
-* [CB-8797](https://issues.apache.org/jira/browse/CB-8797) - Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen` (**iOS**) are missing
-* [CB-8836](https://issues.apache.org/jira/browse/CB-8836) - Crashes after animating `splashscreen`
+* [CB-8797](https://issues.apache.org/jira/browse/CB-8797) Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen` (**iOS**) are missing
+* [CB-8836](https://issues.apache.org/jira/browse/CB-8836) Crashes after animating `splashscreen`
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Fix missing import in previous commit
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Adds `SplashMaintainAspectRatio` preference (close #43)
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -91,9 +91,7 @@ cordova-plugin-battery-status@1.0.0
 
 * [CB-8808](https://issues.apache.org/jira/browse/CB-8808) Fixed tests to pass on **Windows Phone 8.1**
 * [CB-8831](https://issues.apache.org/jira/browse/CB-8831) Adds extra check for available `API` on **Windows**
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
@@ -116,7 +114,6 @@ cordova-plugin-camera@1.0.0
 * [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Removing `FileHelper` call that was failing on Samsung Galaxy S3, now that we have a real path, we only need to update the `MediaStore`, not pull from it in this case
 * [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Partial fix for Save Image to Gallery error found in `MobileSpec`
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8351](https://issues.apache.org/jira/browse/CB-8351) Fix custom implementation of `integerValueForKey`
 * Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install **paramedic**
 * docs: added **Windows** to supported platforms
@@ -126,7 +123,6 @@ cordova-plugin-camera@1.0.0
 cordova-plugin-console@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install ***paramedic** by **npm**
 * docs: renamed **Windows8** to **Windows**
 * [CB-8560](https://issues.apache.org/jira/browse/CB-8560) Integrate **TravisCI**
@@ -137,7 +133,6 @@ cordova-plugin-contacts@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **wp** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
@@ -149,7 +144,6 @@ cordova-plugin-contacts@1.0.0
 cordova-plugin-device@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * remove defunct **windows8** version
 * add travis badge
@@ -160,7 +154,6 @@ cordova-plugin-device-motion@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8312](https://issues.apache.org/jira/browse/CB-8312) Multiply accelerometer values by -g on **Windows**
 * [CB-8562](https://issues.apache.org/jira/browse/CB-8562) Integrate **TravisCI**
@@ -173,7 +166,6 @@ cordova-plugin-device-orientation@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
@@ -189,8 +181,6 @@ cordova-plugin-dialogs@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated wp and bb specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate **TravisCI**
@@ -203,7 +193,6 @@ cordova-plugin-file@2.0.0
 * [CB-8819](https://issues.apache.org/jira/browse/CB-8819) Fixed FileReader's `readAsBinaryString` on **wp8**
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) **Android** Fix broken unit tests from plugin rename
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * docs: added **Windows** to supported platforms
 * [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Fix uncompressed assets being copied as zero length files
@@ -247,7 +236,6 @@ cordova-plugin-file-transfer@1.0.0
 * [CB-8589](https://issues.apache.org/jira/browse/CB-8589) Fixes upload failure when server's response doesn't contain any data
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8654](https://issues.apache.org/jira/browse/CB-8654) Note **WP8** download requests caching in docs
 * [CB-8590](https://issues.apache.org/jira/browse/CB-8590) **Windows** Fixed `download.onprogress.lengthComputable`
@@ -267,7 +255,6 @@ cordova-plugin-file-transfer@1.0.0
 cordova-plugin-geolocation@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8681](https://issues.apache.org/jira/browse/CB-8681) Fixed occasional test failures
 * docs: added **Windows** to supported platforms
@@ -282,7 +269,6 @@ cordova-plugin-globalization@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **tizen** and **Browser** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * separate section in `plugin.xml` and docs for **Windows8** platform
 * [CB-7960](https://issues.apache.org/jira/browse/CB-7960) **Browser** Add support
@@ -299,7 +285,6 @@ cordova-plugin-inappbrowser@1.0.0
 * [CB-8661](https://issues.apache.org/jira/browse/CB-8661) Return executed script result on **Windows**
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **WP** and **Browser** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8432](https://issues.apache.org/jira/browse/CB-8432) Correct styles for **Browser** wrapper to display it correctly on some pages
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x
@@ -321,7 +306,6 @@ cordova-plugin-media@1.0.0
 * [CB-8779](https://issues.apache.org/jira/browse/CB-8779) Fixed media status reporting on **wp8**
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8541](https://issues.apache.org/jira/browse/CB-8541) Adds information about available recording formats on **Windows**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
@@ -339,7 +323,6 @@ cordova-plugin-media-capture@1.0.0
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8687](https://issues.apache.org/jira/browse/CB-8687) consolidate manifest targets
 * [CB-7963](https://issues.apache.org/jira/browse/CB-7963) Adds support for **Browser** platform
@@ -350,7 +333,6 @@ cordova-plugin-media-capture@1.0.0
 cordova-plugin-network-information@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Fixes typo in `cordova.platformId`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Use `navigator.onLine` as connection information source on **Browser** platform
@@ -365,8 +347,6 @@ cordova-plugin-splashscreen@2.0.0
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Fix missing import in previous commit
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Adds `SplashMaintainAspectRatio` preference
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8345](https://issues.apache.org/jira/browse/CB-8345) Make default for splashscreen resource `screen` (which is what template and **CLI** assume it to be)
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * docs: added **Windows** to supported platforms
@@ -379,7 +359,6 @@ cordova-plugin-splashscreen@2.0.0
 cordova-plugin-statusbar@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme
 * Add support for `StatusBar.backgroundColorByHexString` (and `StatusBar.backgroundColorByName`) on **Android 5** and up
@@ -398,7 +377,6 @@ cordova-plugin-test-framework@1.0.0
 cordova-plugin-vibration@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Reference proxy project instead of compiled `winmd`
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Add `cordova-plugin-vibration` support for **Windows Phone 8.1**
 * [CB-8576](https://issues.apache.org/jira/browse/CB-8576) Integrate **TravisCI**

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -66,6 +66,7 @@ Plugin changes include:
 <!--more-->
 
 cordova-plugin-battery-status@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8808](https://issues.apache.org/jira/browse/CB-8808) Fixed tests to pass on **Windows Phone 8.1**
 * [CB-8831](https://issues.apache.org/jira/browse/CB-8831) Adds extra check for available `API` on **Windows**
@@ -81,6 +82,7 @@ cordova-plugin-battery-status@1.0.0
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-camera@1.0.0
+
 * [CB-8780](https://issues.apache.org/jira/browse/CB-8780) - Display popover using main thread. Fixes popover slowness (closes #81)
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
@@ -102,6 +104,7 @@ cordova-plugin-camera@1.0.0
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659): **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 
 cordova-plugin-console@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -112,6 +115,7 @@ cordova-plugin-console@1.0.0
 * [CB-8362](https://issues.apache.org/jira/browse/CB-8362) Add **Windows** platform section to Console plugin
 
 cordova-plugin-contacts@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **wp** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
@@ -125,6 +129,7 @@ cordova-plugin-contacts@1.0.0
 * [CB-8395](https://issues.apache.org/jira/browse/CB-8395) marked unsupported tests pending on **wp8**
 
 cordova-plugin-device@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -135,6 +140,7 @@ cordova-plugin-device@1.0.0
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-device-motion@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
@@ -148,6 +154,7 @@ cordova-plugin-device-motion@1.0.0
 * [CB-8083](https://issues.apache.org/jira/browse/CB-8083) Adds test to make sure success callback is called each time
 
 cordova-plugin-device-orientation@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
@@ -164,6 +171,7 @@ cordova-plugin-device-orientation@1.0.0
 * [CB-8458](https://issues.apache.org/jira/browse/CB-8458) Fixes false failure of test, when compass hardware is not available
 
 cordova-plugin-dialogs@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated wp and bb specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
@@ -176,6 +184,7 @@ cordova-plugin-dialogs@1.0.0
 * [CB-8367](https://issues.apache.org/jira/browse/CB-8367) [org.apache.cordova.dialogs] Add Prompt support on **Windows**
 
 cordova-plugin-file@2.0.0
+
 * [CB-8849](https://issues.apache.org/jira/browse/CB-8849) Fixed `ReadAsArrayBuffer` to return `ArrayBuffer` and not Array on **WP8**
 * [CB-8819](https://issues.apache.org/jira/browse/CB-8819) Fixed FileReader's `readAsBinaryString` on **wp8**
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
@@ -218,6 +227,7 @@ cordova-plugin-file@2.0.0
 * Added `nativeURL` property to `FileEntry`, implemented `readAsArrayBuffer` and `readAsBinaryString`
 
 cordova-plugin-file-transfer@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8641](https://issues.apache.org/jira/browse/CB-8641) Fixed tests to pass on **Windows** and **wp8**
@@ -243,6 +253,7 @@ cordova-plugin-file-transfer@1.0.0
 * **Android**: Fix error reporting for unknown `uri` type on `sourceUri` instead of `targetUri`
 
 cordova-plugin-geolocation@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -257,6 +268,7 @@ cordova-plugin-geolocation@1.0.0
 * [CB-8443](https://issues.apache.org/jira/browse/CB-8443) Geolocation tests fail on **Windows** due to done is called multiple times
 
 cordova-plugin-globalization@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **tizen** and **Browser** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
@@ -270,6 +282,7 @@ cordova-plugin-globalization@1.0.0
 * [CB-8394](https://issues.apache.org/jira/browse/CB-8394) pended unsupported tests for **Windows** and **wp8**
 
 cordova-plugin-inappbrowser@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-7689](https://issues.apache.org/jira/browse/CB-7689) Adds `insertCSS` support for **Windows** platform
 * [CB-4930](https://issues.apache.org/jira/browse/CB-4930) - (prefix) InAppBrowser should take into account the status bar
@@ -293,6 +306,7 @@ cordova-plugin-inappbrowser@1.0.0
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Don't clobber `window.open` - Add new symbol/clobber to access open function (`cordova.InAppBrowser.open`) - Change existing tests to use new symbol (i.e. don't rely on plugin clobber of `window.open`) - Add tests to use `window.open` via manual replace with new symbol - Update docs to deprecate plugin clobber of `window.open`
 
 cordova-plugin-media@1.0.0
+
 * [CB-8793](https://issues.apache.org/jira/browse/CB-8793) Fixed tests to pass on **wp8** and **Windows**
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
@@ -313,6 +327,7 @@ cordova-plugin-media@1.0.0
 * [CB-8425](https://issues.apache.org/jira/browse/CB-8425) Media plugin `.ctr`: make src param required as per spec
 
 cordova-plugin-media-capture@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
@@ -326,6 +341,7 @@ cordova-plugin-media-capture@1.0.0
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-network-information@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -337,6 +353,7 @@ cordova-plugin-network-information@1.0.0
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-splashscreen@2.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8797](https://issues.apache.org/jira/browse/CB-8797) - Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen` (**iOS**) are missing
 * [CB-8836](https://issues.apache.org/jira/browse/CB-8836) - Crashes after animating `splashscreen`
@@ -355,6 +372,7 @@ cordova-plugin-splashscreen@2.0.0
 * [CB-8397](https://issues.apache.org/jira/browse/CB-8397) Add support to **Windows** for showing the **Windows Phone** splashscreen
 
 cordova-plugin-statusbar@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -366,6 +384,7 @@ cordova-plugin-statusbar@1.0.0
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-test-framework@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Add a shim for `jasmine.Expectation.addMatchers` being moved in **jasmine 2.2.0**
@@ -374,6 +393,7 @@ cordova-plugin-test-framework@1.0.0
 * [CB-8385](https://issues.apache.org/jira/browse/CB-8385) Ensure `plugin-test-framework` trigger tests only once
 
 cordova-plugin-vibration@1.0.0
+
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -97,7 +97,7 @@ cordova-plugin-battery-status@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWithWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWithWebView` method
 * added apache/travis badge - will not show until INFRA updates the github integration
 * add `travis.yml` for CI with paramedic
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -121,7 +121,7 @@ cordova-plugin-camera@1.0.0
 * Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install **paramedic**
 * docs: added **Windows** to supported platforms
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 
 cordova-plugin-console@1.0.0
 
@@ -139,8 +139,8 @@ cordova-plugin-contacts@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * [CB-8604](https://issues.apache.org/jira/browse/CB-8604) Pended unsupported test for **wp8**, updated documentation
 * [CB-8561](https://issues.apache.org/jira/browse/CB-8561) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -176,8 +176,8 @@ cordova-plugin-device-orientation@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * force async callbacks
 * Updated plugin to be **Windows** instead of **Windows8**
 * [CB-8614](https://issues.apache.org/jira/browse/CB-8614) Fixed `getCurrentHeading` and `watchHeading` on **Windows** platform
@@ -192,7 +192,7 @@ cordova-plugin-dialogs@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8367](https://issues.apache.org/jira/browse/CB-8367) [org.apache.cordova.dialogs] Add Prompt support on **Windows**
@@ -215,7 +215,7 @@ cordova-plugin-file@2.0.0
 * Tweak build-extras.gradle to just read/write to main `assets/` instead of `build/`
 * [CB-8689](https://issues.apache.org/jira/browse/CB-8689) Fix `NPE` in `makeEntryForNativeUri` (was affecting file-transfer)
 * [CB-8675](https://issues.apache.org/jira/browse/CB-8675) Revert "CB-8351 ios: Use `base64EncodedStringWithOptions` instead of `CordovaLib's` class extension"
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * Add a cache to speed up `AssetFilesystem` directory listings
 * [CB-8663](https://issues.apache.org/jira/browse/CB-8663) **Android**: Don't notify `MediaScanner` of private files
 * Don't log stacktrace for normal exceptions (e.g. file not found)
@@ -271,8 +271,8 @@ cordova-plugin-geolocation@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8681](https://issues.apache.org/jira/browse/CB-8681) Fixed occasional test failures
 * docs: added **Windows** to supported platforms
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * Wrong parameter in **Firefox OS** plugin
 * [CB-8568](https://issues.apache.org/jira/browse/CB-8568) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -286,7 +286,7 @@ cordova-plugin-globalization@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * separate section in `plugin.xml` and docs for **Windows8** platform
 * [CB-7960](https://issues.apache.org/jira/browse/CB-7960) Add `cordova-plugin-globalization` support for **Browser** platform
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8394](https://issues.apache.org/jira/browse/CB-8394) pended unsupported tests for **Windows** and **wp8**
@@ -326,7 +326,7 @@ cordova-plugin-media@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
 * [CB-7962](https://issues.apache.org/jira/browse/CB-7962) Adds **Browser** platform support
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix tests on **Windows** if no audio playback hardware is available
@@ -343,7 +343,7 @@ cordova-plugin-media-capture@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8687](https://issues.apache.org/jira/browse/CB-8687) consolidate manifest targets
 * [CB-7963](https://issues.apache.org/jira/browse/CB-7963) Adds support for **Browser** platform
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8571](https://issues.apache.org/jira/browse/CB-8571) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
@@ -354,7 +354,7 @@ cordova-plugin-network-information@1.0.0
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Fixes typo in `cordova.platformId`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Use `navigator.onLine` as connection information source on **Browser** platform
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8573](https://issues.apache.org/jira/browse/CB-8573) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -89,26 +89,25 @@ Plugin changes include:
 
 cordova-plugin-battery-status@1.0.0
 
-* [CB-8808](https://issues.apache.org/jira/browse/CB-8808) Fixed tests to pass on **Windows Phone 8.1**
-* [CB-8831](https://issues.apache.org/jira/browse/CB-8831) Adds extra check for available `API` on **Windows**
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* add `travis.yml` for CI with **paramedic**
+* added apache/travis badge - will not show until INFRA updates the github integration
+* [CB-8808](https://issues.apache.org/jira/browse/CB-8808) Fixed tests to pass on **Windows Phone 8.1**
+* [CB-8831](https://issues.apache.org/jira/browse/CB-8831) **Windows** Adds extra check for available `API`
 * add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWithWebView` method
-* added apache/travis badge - will not show until INFRA updates the github integration
-* add `travis.yml` for CI with paramedic
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-camera@1.0.0
 
+* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
 * [CB-8780](https://issues.apache.org/jira/browse/CB-8780) Display popover using main thread. Fixes popover slowness
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8707](https://issues.apache.org/jira/browse/CB-8707) refactoring **Windows** code to improve readability
 * [CB-8706](https://issues.apache.org/jira/browse/CB-8706) use `filePicker` if `saveToPhotoAlbum` is true
 * [CB-8706](https://issues.apache.org/jira/browse/CB-8706) remove unnecessary capabilities from `xml`
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Blackberry** specific references of `org.apache.cordova.camera` to `cordova-plugin-camera`
 * [CB-8782](https://issues.apache.org/jira/browse/CB-8782) Updated the docs to talk about the `allowEdit` quirks, it's not 100% working, but better than it was
 * [CB-8782](https://issues.apache.org/jira/browse/CB-8782) Fixed the flow so that we save the cropped image and use it, not the original non-cropped.  Crop only supports G+ Photos Crop, other crops may not work, depending on the OEM
 * [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Removing `FileHelper` call that was failing on Samsung Galaxy S3, now that we have a real path, we only need to update the `MediaStore`, not pull from it in this case
@@ -116,213 +115,214 @@ cordova-plugin-camera@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8351](https://issues.apache.org/jira/browse/CB-8351) Fix custom implementation of `integerValueForKey`
 * Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install **paramedic**
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) **BlackBerry** updated references of `org.apache.cordova.camera` to `cordova-plugin-camera`
+* [CB-8707](https://issues.apache.org/jira/browse/CB-8707) **Windows** refactoring code to improve readability
 * docs: added **Windows** to supported platforms
-* [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 
 cordova-plugin-console@1.0.0
 
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8560](https://issues.apache.org/jira/browse/CB-8560) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install ***paramedic** by **npm**
 * docs: renamed **Windows8** to **Windows**
-* [CB-8560](https://issues.apache.org/jira/browse/CB-8560) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8362](https://issues.apache.org/jira/browse/CB-8362) Add **Windows** platform section to Console plugin
 
 cordova-plugin-contacts@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **wp** specific references of old id to new id
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8561](https://issues.apache.org/jira/browse/CB-8561) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **wp** specific references of old id to new id
 * [CB-8604](https://issues.apache.org/jira/browse/CB-8604) Pended unsupported test for **wp8**, updated documentation
-* [CB-8561](https://issues.apache.org/jira/browse/CB-8561) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8395](https://issues.apache.org/jira/browse/CB-8395) marked unsupported tests pending on **wp8**
 
 cordova-plugin-device@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* remove defunct **windows8** version
-* add travis badge
-* Add cross-plugin ios paramedic test running for **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* add travis badge
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* Add cross-plugin **iOS** **paramedic** test running for **TravisCI**
+* remove defunct **windows8** version
 
 cordova-plugin-device-motion@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** specific references of old id to new id
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8312](https://issues.apache.org/jira/browse/CB-8312) Multiply accelerometer values by -g on **Windows**
-* [CB-8562](https://issues.apache.org/jira/browse/CB-8562) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended recently added spec.12 if accelerometer doesn't exist on the device
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+specific references of old id to new id
+* [CB-8562](https://issues.apache.org/jira/browse/CB-8562) Integrate **TravisCI**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** * [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended recently added spec.12 if accelerometer doesn't exist on the device
 * [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended auto tests if accelerometer doesn't exist on the device
 * [CB-8083](https://issues.apache.org/jira/browse/CB-8083) Adds test to make sure success callback is called each time
+* [CB-8312](https://issues.apache.org/jira/browse/CB-8312) Multiply accelerometer values by -g on **Windows**
 
 cordova-plugin-device-orientation@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **tizen** specific references of old id to new id
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8563](https://issues.apache.org/jira/browse/CB-8563) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** specific references of old id to new id
+* [CB-8458](https://issues.apache.org/jira/browse/CB-8458) Fixes false failure of test, when compass hardware is not available
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * force async callbacks
 * Updated plugin to be **Windows** instead of **Windows8**
-* [CB-8614](https://issues.apache.org/jira/browse/CB-8614) Fixed `getCurrentHeading` and `watchHeading` on **Windows** platform
-* [CB-8563](https://issues.apache.org/jira/browse/CB-8563) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8458](https://issues.apache.org/jira/browse/CB-8458) Fixes false failure of test, when compass hardware is not available
+* [CB-8614](https://issues.apache.org/jira/browse/CB-8614) **Windows** Fixed `getCurrentHeading` and `watchHeading`
 
 cordova-plugin-dialogs@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated wp and bb specific references of old id to new id
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
-* [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8367](https://issues.apache.org/jira/browse/CB-8367) Add Prompt support on **Windows**
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate **TravisCI**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated wp and bb specific references of old id to new id
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
+* [CB-8367](https://issues.apache.org/jira/browse/CB-8367) **Windows** Add Prompt support
 
 cordova-plugin-file@2.0.0
 
-* [CB-8849](https://issues.apache.org/jira/browse/CB-8849) Fixed `ReadAsArrayBuffer` to return `ArrayBuffer` and not Array on **WP8**
-* [CB-8819](https://issues.apache.org/jira/browse/CB-8819) Fixed FileReader's `readAsBinaryString` on **wp8**
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) **Android** Fix broken unit tests from plugin rename
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* docs: added **Windows** to supported platforms
-* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Fix uncompressed assets being copied as zero length files
-* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android**: Fix assets `FileEntry` having size of -1
-* **Android**: Move `URLforFullPath` into base class (and rename to `localUrlforFullPath`)
-* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Mention `build-extras.gradle` in README
-* [CB-7109](https://issues.apache.org/jira/browse/CB-7109) **Android**: Parse arguments off of the main thread
-* [CB-8695](https://issues.apache.org/jira/browse/CB-8695) **iOS**: Fix `blob.slice()` for `asset-library` URLs
-* Tweak build-extras.gradle to just read/write to main `assets/` instead of `build/`
-* [CB-8689](https://issues.apache.org/jira/browse/CB-8689) Fix `NPE` in `makeEntryForNativeUri` (was affecting file-transfer)
-* [CB-8675](https://issues.apache.org/jira/browse/CB-8675) Revert "CB-8351 ios: Use `base64EncodedStringWithOptions` instead of `CordovaLib's` class extension"
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
-* Add a cache to speed up `AssetFilesystem` directory listings
-* [CB-8663](https://issues.apache.org/jira/browse/CB-8663) **Android**: Don't notify `MediaScanner` of private files
-* Don't log stacktrace for normal exceptions (e.g. file not found)
-* **Android**: Don't use LimitedInputStream when reading entire file (optimization)
-* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android**: Add support for directory copies from assets -> filesystem
-* **Android**: Add `listChildren()`: Java-consumable version of `readEntriesAtLocalURL()`
-* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android**: Add support for `file:///android_asset` URLs
-* [CB-8642](https://issues.apache.org/jira/browse/CB-8642) **Android**: Fix content URIs not working with resolve / copy
-* Tweak tests to fail if `deleteEntry` fails (rather than time out)
-* **Android**: Ensure `LocalFilesystemURL` can only be created with `cdvfile` URLs
-* **Android**: Move `CordovaResourceApi` into Filesystem base class
-* **Android**: Use `CordovaResourceApi.mapUriToFile()` rather than own custom logic in `ContentFilesystem`
-* **Android**: Use Uri.parse rather than manual parsing in resolveLocalFileSystemURI
-* **Android**: Delete invalid `JavaDoc` (lint errors)
-* **Android**: Use `CordovaResourceAp`i rather than `FileHelper`
-* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:`
-* [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-7956](https://issues.apache.org/jira/browse/CB-7956) **Browser** Add support
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate **TravisCI**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* [CB-8689](https://issues.apache.org/jira/browse/CB-8689) Fix `NPE` in `makeEntryForNativeUri` (was affecting file-transfer)
+* Add a cache to speed up `AssetFilesystem` directory listings
+* Don't log stacktrace for normal exceptions (e.g. file not found)
+* Tweak tests to fail if `deleteEntry` fails (rather than time out)
+* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:`
 * [CB-8423](https://issues.apache.org/jira/browse/CB-8423) Corrected usage of `done()` in async tests
 * [CB-8459](https://issues.apache.org/jira/browse/CB-8459) Fixes spec 111 failure due to incorrect relative paths handling
 * Added `nativeURL` property to `FileEntry`, implemented `readAsArrayBuffer` and `readAsBinaryString`
+* [CB-8675](https://issues.apache.org/jira/browse/CB-8675) Revert "CB-8351 **iOS**: Use `base64EncodedStringWithOptions` instead of `CordovaLib's` class extension"
+* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Fix uncompressed assets being copied as zero length files
+* [CB-8695](https://issues.apache.org/jira/browse/CB-8695) **iOS** Fix `blob.slice()` for `asset-library` URLs
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
+* **Android** Tweak `build-extras.gradle` to just read/write to main `assets/` instead of `build/`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) **Android** Fix broken unit tests from plugin rename
+* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android** Fix assets `FileEntry` having size of -1
+* **Android** Move `URLforFullPath` into base class (and rename to `localUrlforFullPath`)
+* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android** Mention `build-extras.gradle` in README
+* [CB-7109](https://issues.apache.org/jira/browse/CB-7109) **Android** Parse arguments off of the main thread
+* [CB-8663](https://issues.apache.org/jira/browse/CB-8663) **Android** Don't notify `MediaScanner` of private files
+* **Android** Don't use LimitedInputStream when reading entire file (optimization)
+* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android** Add support for directory copies from assets -> filesystem
+* **Android** Add `listChildren()`: Java-consumable version of `readEntriesAtLocalURL()`
+* [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android** Add support for `file:///android_asset` URLs
+* [CB-8642](https://issues.apache.org/jira/browse/CB-8642) **Android** Fix content URIs not working with resolve / copy
+* **Android** Ensure `LocalFilesystemURL` can only be created with `cdvfile` URLs
+* **Android** Move `CordovaResourceApi` into Filesystem base class
+* **Android** Use `CordovaResourceApi.mapUriToFile()` rather than own custom logic in `ContentFilesystem`
+* **Android** Use Uri.parse rather than manual parsing in resolveLocalFileSystemURI
+* **Android** Delete invalid `JavaDoc` (lint errors)
+* **Android** Use `CordovaResourceAp`i rather than `FileHelper`
+* [CB-7956](https://issues.apache.org/jira/browse/CB-7956) **Browser** Add support
+* [CB-8849](https://issues.apache.org/jira/browse/CB-8849) **WP8** Fixed `ReadAsArrayBuffer` to return `ArrayBuffer` and not Array
+* [CB-8819](https://issues.apache.org/jira/browse/CB-8819) **wp8** Fixed FileReader's `readAsBinaryString`
+* docs: added **Windows** to supported platforms
 
 cordova-plugin-file-transfer@1.0.0
 
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8566](https://issues.apache.org/jira/browse/CB-8566) Integrate **TravisCI**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8641](https://issues.apache.org/jira/browse/CB-8641) Fixed tests to pass on **Windows** and **wp8**
 * [CB-8583](https://issues.apache.org/jira/browse/CB-8583) Forces download to overwrite existing target file
 * [CB-8589](https://issues.apache.org/jira/browse/CB-8589) Fixes upload failure when server's response doesn't contain any data
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8654](https://issues.apache.org/jira/browse/CB-8654) Note **WP8** download requests caching in docs
-* [CB-8590](https://issues.apache.org/jira/browse/CB-8590) **Windows** Fixed `download.onprogress.lengthComputable`
-* [CB-8566](https://issues.apache.org/jira/browse/CB-8566) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8495](https://issues.apache.org/jira/browse/CB-8495) Fixed **wp8** and **wp8.1** test failures
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Use File proxy to construct valid FileEntry for download success callback
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Removes excess path to native path conversion in download method
 * [CB-8429](https://issues.apache.org/jira/browse/CB-8429) Updated version and `RELEASENOTES.md` for release 0.5.0
-* [CB-7957](https://issues.apache.org/jira/browse/CB-7957) **Browser** Add support
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Fixes JSHint and formatting issues
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Updates tests and documentation
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Rewrite upload method to support progress events properly
-* **Android**: Fix error reporting for unknown `uri` type on `sourceUri` instead of `targetUri`
+* **Android** Fix error reporting for unknown `uri` type on `sourceUri` instead of `targetUri`
+* [CB-7957](https://issues.apache.org/jira/browse/CB-7957) **Browser** Add support
+* [CB-8641](https://issues.apache.org/jira/browse/CB-8641) Fixed tests to pass on **Windows** and **wp8**
+* [CB-8654](https://issues.apache.org/jira/browse/CB-8654) Note **WP8** download requests caching in docs
+* [CB-8590](https://issues.apache.org/jira/browse/CB-8590) **Windows** Fixed `download.onprogress.lengthComputable`
+* [CB-8495](https://issues.apache.org/jira/browse/CB-8495) Fixed **wp8** and **wp8.1** test failures
 
 cordova-plugin-geolocation@1.0.0
 
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8568](https://issues.apache.org/jira/browse/CB-8568) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8681](https://issues.apache.org/jira/browse/CB-8681) Fixed occasional test failures
-* docs: added **Windows** to supported platforms
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * Wrong parameter in **Firefox OS** plugin
-* [CB-8568](https://issues.apache.org/jira/browse/CB-8568) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8443](https://issues.apache.org/jira/browse/CB-8443) Geolocation tests fail on **Windows** due to done is called multiple times
+* docs: added **Windows** to supported platforms
 
 cordova-plugin-globalization@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **tizen** and **Browser** specific references of old id to new id
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* separate section in `plugin.xml` and docs for **Windows8** platform
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **tizen** and **Browser** specific references of old id to new id
 * [CB-7960](https://issues.apache.org/jira/browse/CB-7960) **Browser** Add support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
-* [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8394](https://issues.apache.org/jira/browse/CB-8394) pended unsupported tests for **Windows** and **wp8**
+* separate section in `plugin.xml` and docs for **Windows8** platform
 
 cordova-plugin-inappbrowser@1.0.0
 
-* [CB-7689](https://issues.apache.org/jira/browse/CB-7689) Adds `insertCSS` support for **Windows** platform
-* [CB-4930](https://issues.apache.org/jira/browse/CB-4930) (prefix) InAppBrowser should take into account the status bar
-* [CB-8635](https://issues.apache.org/jira/browse/CB-8635) Improves UX on **Windows** platform
-* [CB-8661](https://issues.apache.org/jira/browse/CB-8661) Return executed script result on **Windows**
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **WP** and **Browser** specific references of old id to new id
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8432](https://issues.apache.org/jira/browse/CB-8432) Correct styles for **Browser** wrapper to display it correctly on some pages
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x
-* [CB-7961](https://issues.apache.org/jira/browse/CB-7961) **Browser** Add support
-* Update docs for **Android** `zoom=no` option
+* [CB-4930](https://issues.apache.org/jira/browse/CB-4930) (prefix) InAppBrowser should take into account the status bar
 * Added option to disable/enable zoom controls
 * updated docs, set `hardwareback` default to true
 * Add a `hardwareback` option to allow for the hardware back button to go back
-* [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* Keep external **Android** pages in a single tab
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Add a clobber for `cordova.InAppBrowser.open`
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Don't clobber `window.open` - Add new symbol/clobber to access open function (`cordova.InAppBrowser.open`) Change existing tests to use new symbol (i.e. don't rely on plugin clobber of `window.open`) - Add tests to use `window.open` via manual replace with new symbol - Update docs to deprecate plugin clobber of `window.open`
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x
+* Update docs for **Android** `zoom=no` option
+* Keep external **Android** pages in a single tab
+* [CB-7961](https://issues.apache.org/jira/browse/CB-7961) **Browser** Add support
+* [CB-8432](https://issues.apache.org/jira/browse/CB-8432) Correct styles for **Browser** wrapper to display it correctly on some pages
+* [CB-7689](https://issues.apache.org/jira/browse/CB-7689) Adds `insertCSS` support for **Windows** platform
+* [CB-8635](https://issues.apache.org/jira/browse/CB-8635) Improves UX on **Windows** platform
+* [CB-8661](https://issues.apache.org/jira/browse/CB-8661) Return executed script result on **Windows**
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **WP** and **Browser** specific references of old id to new id
 
 cordova-plugin-media@1.0.0
 
-* [CB-8793](https://issues.apache.org/jira/browse/CB-8793) Fixed tests to pass on **wp8** and **Windows**
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8779](https://issues.apache.org/jira/browse/CB-8779) Fixed media status reporting on **wp8**
-* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* [CB-8541](https://issues.apache.org/jira/browse/CB-8541) Adds information about available recording formats on **Windows**
-* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
-* [CB-7962](https://issues.apache.org/jira/browse/CB-7962) **Browser** Add support
-* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
-* [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix tests on **Windows** if no audio playback hardware is available
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate **TravisCI**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
+* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
+* [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
 * [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix multiple `done()` calls in media plugin test on devices where audio is not configured
-* [CB-8426](https://issues.apache.org/jira/browse/CB-8426) Add **Windows** platform section to Media plugin
 * [CB-8425](https://issues.apache.org/jira/browse/CB-8425) Media plugin `.ctr`: make src param required as per spec
+* [CB-7962](https://issues.apache.org/jira/browse/CB-7962) Adds **Browser** platform support
+* [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
+* [CB-8793](https://issues.apache.org/jira/browse/CB-8793) Fixed tests to pass on **wp8** and **Windows**
+* [CB-8779](https://issues.apache.org/jira/browse/CB-8779) Fixed media status reporting on **wp8**
+* [CB-8541](https://issues.apache.org/jira/browse/CB-8541) Adds information about available recording formats on **Windows**
+* [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix tests on **Windows** if no audio playback hardware is available
+* [CB-8426](https://issues.apache.org/jira/browse/CB-8426) Add **Windows** platform section to Media plugin
 
 cordova-plugin-media-capture@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
+* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8687](https://issues.apache.org/jira/browse/CB-8687) consolidate manifest targets
 * [CB-7963](https://issues.apache.org/jira/browse/CB-7963) **Browser** Add support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
@@ -341,45 +341,45 @@ cordova-plugin-network-information@1.0.0
 
 cordova-plugin-splashscreen@2.0.0
 
-* [CB-8797](https://issues.apache.org/jira/browse/CB-8797) Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen` (**iOS**) are missing
-* [CB-8836](https://issues.apache.org/jira/browse/CB-8836) Crashes after animating `splashscreen`
-* [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Fix missing import in previous commit
-* [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Adds `SplashMaintainAspectRatio` preference
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8574](https://issues.apache.org/jira/browse/CB-8574) Integrate **TravisCI**
 * [CB-8345](https://issues.apache.org/jira/browse/CB-8345) Make default for splashscreen resource `screen` (which is what template and **CLI** assume it to be)
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
+* [CB-8836](https://issues.apache.org/jira/browse/CB-8836) Crashes after animating `splashscreen`
+* [CB-8797](https://issues.apache.org/jira/browse/CB-8797) **iOS** add Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen`
+* [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android** Fix missing import in previous commit
+* [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android** Adds `SplashMaintainAspectRatio` preference
 * docs: added **Windows** to supported platforms
-* [CB-7964](https://issues.apache.org/jira/browse/CB-7964) Add `cordova-plugin-splashscreen` support for **browser** platform
-* Extend **WP8** Splash Screen to respect `SplashScreen` and `SplashScreenDelay` preferences from config file
-* [CB-8574](https://issues.apache.org/jira/browse/CB-8574) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8397](https://issues.apache.org/jira/browse/CB-8397) Add support to **Windows** for showing the **Windows Phone** splashscreen
+* [CB-7964](https://issues.apache.org/jira/browse/CB-7964) **browser** Add support
+* **WP8** respect `SplashScreen` and `SplashScreenDelay` preferences from config file
+* [CB-8397](https://issues.apache.org/jira/browse/CB-8397) **Windows** support showing the **Windows Phone** splashscreen
 
 cordova-plugin-statusbar@1.0.0
 
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8575](https://issues.apache.org/jira/browse/CB-8575) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme
-* Add support for `StatusBar.backgroundColorByHexString` (and `StatusBar.backgroundColorByName`) on **Android 5** and up
-* Allow setting the `statusbar backgroundcolor` on **Android**
-* [CB-8575](https://issues.apache.org/jira/browse/CB-8575) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
+* **Android 5+** Add support for `StatusBar.backgroundColorByHexString` (and `StatusBar.backgroundColorByName`)
+* **Android** Allow setting the `statusbar backgroundcolor`
 
 cordova-plugin-test-framework@1.0.0
 
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Add a shim for `jasmine.Expectation.addMatchers` being moved in **jasmine 2.2.0**
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Update test framework plugin to use **Jasmine 2.2.0**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8385](https://issues.apache.org/jira/browse/CB-8385) Ensure `plugin-test-framework` trigger tests only once
 
 cordova-plugin-vibration@1.0.0
 
+* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8576](https://issues.apache.org/jira/browse/CB-8576) Integrate **TravisCI**
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Reference proxy project instead of compiled `winmd`
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Add `cordova-plugin-vibration` support for **Windows Phone 8.1**
-* [CB-8576](https://issues.apache.org/jira/browse/CB-8576) Integrate **TravisCI**
-* [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 [npm]: https://www.npmjs.org/
 [CPR]: http://plugins.cordova.io

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -8,13 +8,13 @@ categories: announcement release
 tags: plugins announcement releass
 ---
 
-The **Apache Cordova** team is happy to announce a new plugins release that coincides with us moving our core plugins to **[npm](://www.npmjs.org/)**! We are also encouraging third party plugin developers to start publishing their plugins to npm! To start using plugins from **npm**, developers will have to update their **Cordova CLI** to version 5.0.0 or higher. 
+The **Apache Cordova** team is happy to announce a new plugins release that coincides with us moving our core plugins to **[npm]**! We are also encouraging third party plugin developers to start publishing their plugins to npm! To start using plugins from **npm**, developers will have to update their **Cordova CLI** to version 5.0.0 or higher.
 
 With the move over to **npm**, we have decided to rename our core plugins for improved readability and to better fit within the npm ecosystem. All of our core plugins have changed their IDs from `org.apache.cordova.*` to `cordova-plugin-*`. Developers can now install a plugin with the command `cordova plugin add cordova-plugin-device`. Using the new ID will fetch the plugin directly from **npm**. 
 
-Our current **Cordova plugins registry** (CPR), [plugins.cordova.io](http://plugins.cordova.io) will continue to be operational for at least 6 months (October 15th, 2015) as we help plugin developers with transitioning over to **npm**. This will also allow current **Cordova** developers to upgrade their `CLI` to version 5.0.0 or higher. We will be switching **CPR** to read-only on July 15th, 2015.
+Our current **Cordova plugins registry** [CPR] will continue to be operational for at least 6 months (October 15th, 2015) as we help plugin developers with transitioning over to **npm**. This will also allow current **Cordova** developers to upgrade their `CLI` to version 5.0.0 or higher. We will be switching **CPR** to read-only on July 15th, 2015.
 
-To find plugins on **npm**, search for [ecosystem:cordova](https://www.npmjs.com/search?q=ecosystem%3Acordova). We are working with **npm** to improve discoverability and will have more to announce later this year. We encourage all third party plugin developers to add `ecosystem:cordova` as a keyword in their plugin's `package.json`.
+To find plugins on **npm**, search for [ecosystem:cordova]. We are working with **npm** to improve discoverability and will have more to announce later this year. We encourage all third party plugin developers to add `ecosystem:cordova` as a keyword in their plugin's `package.json`.
 
 ## Plugin Authors: Steps to move your plugin to **npm**
 1. **Optional** Decide if you want to change your plugin's `id`. If you decide to change it, update the `id` in `plugin.xml` and update your readme with the new `id`. Next, send a pull request adding your new id and old id to [Cordova Registry Mapper](https://github.com/stevengill/cordova-registry-mapper). We integrate that module into the **Cordova CLI** to warn users to use the new `id` when adding plugins to their projects.

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -90,13 +90,13 @@ Plugin changes include:
 cordova-plugin-battery-status@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* add `travis.yml` for CI with **paramedic**
-* added apache/travis badge - will not show until INFRA updates the github integration
+* Add `travis.yml` for CI with **paramedic**
+* Added apache/travis badge - will not show until INFRA updates the github integration
 * [CB-8808](https://issues.apache.org/jira/browse/CB-8808) Fixed tests to pass on **Windows Phone 8.1**
 * [CB-8831](https://issues.apache.org/jira/browse/CB-8831) **Windows** Adds extra check for available `API`
-* add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
+* Add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWithWebView` method
 
@@ -104,60 +104,60 @@ cordova-plugin-camera@1.0.0
 
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
 * [CB-8780](https://issues.apache.org/jira/browse/CB-8780) Display popover using main thread. Fixes popover slowness
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8706](https://issues.apache.org/jira/browse/CB-8706) use `filePicker` if `saveToPhotoAlbum` is true
-* [CB-8706](https://issues.apache.org/jira/browse/CB-8706) remove unnecessary capabilities from `xml`
-* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
+* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) Bumped version of file dependency
+* [CB-8706](https://issues.apache.org/jira/browse/CB-8706) Use `filePicker` if `saveToPhotoAlbum` is true
+* [CB-8706](https://issues.apache.org/jira/browse/CB-8706) Remove unnecessary capabilities from `xml`
+* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) Updated dependency, added peer dependency
 * [CB-8782](https://issues.apache.org/jira/browse/CB-8782) Updated the docs to talk about the `allowEdit` quirks, it's not 100% working, but better than it was
 * [CB-8782](https://issues.apache.org/jira/browse/CB-8782) Fixed the flow so that we save the cropped image and use it, not the original non-cropped.  Crop only supports G+ Photos Crop, other crops may not work, depending on the OEM
 * [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Removing `FileHelper` call that was failing on Samsung Galaxy S3, now that we have a real path, we only need to update the `MediaStore`, not pull from it in this case
 * [CB-8740](https://issues.apache.org/jira/browse/CB-8740) Partial fix for Save Image to Gallery error found in `MobileSpec`
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8351](https://issues.apache.org/jira/browse/CB-8351) Fix custom implementation of `integerValueForKey`
 * Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install **paramedic**
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) **BlackBerry** updated references of `org.apache.cordova.camera` to `cordova-plugin-camera`
 * [CB-8707](https://issues.apache.org/jira/browse/CB-8707) **Windows** refactoring code to improve readability
-* docs: added **Windows** to supported platforms
+* Docs: added **Windows** to supported platforms
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 
 cordova-plugin-console@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8560](https://issues.apache.org/jira/browse/CB-8560) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install ***paramedic** by **npm**
-* docs: renamed **Windows8** to **Windows**
+* Docs: renamed **Windows8** to **Windows**
 * [CB-8362](https://issues.apache.org/jira/browse/CB-8362) Add **Windows** platform section to Console plugin
 
 cordova-plugin-contacts@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8561](https://issues.apache.org/jira/browse/CB-8561) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **wp** specific references of old id to new id
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Updated **wp** specific references of old id to new id
 * [CB-8604](https://issues.apache.org/jira/browse/CB-8604) Pended unsupported test for **wp8**, updated documentation
-* [CB-8395](https://issues.apache.org/jira/browse/CB-8395) marked unsupported tests pending on **wp8**
+* [CB-8395](https://issues.apache.org/jira/browse/CB-8395) Marked unsupported tests pending on **wp8**
 
 cordova-plugin-device@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
-* add travis badge
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
+* Add travis badge
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * Add cross-plugin **iOS** **paramedic** test running for **TravisCI**
-* remove defunct **windows8** version
+* Remove defunct **windows8** version
 
 cordova-plugin-device-motion@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 specific references of old id to new id
 * [CB-8562](https://issues.apache.org/jira/browse/CB-8562) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** * [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended recently added spec.12 if accelerometer doesn't exist on the device
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Updated **Windows** and **Tizen** * [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended recently added spec.12 if accelerometer doesn't exist on the device
 * [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended auto tests if accelerometer doesn't exist on the device
 * [CB-8083](https://issues.apache.org/jira/browse/CB-8083) Adds test to make sure success callback is called each time
 * [CB-8312](https://issues.apache.org/jira/browse/CB-8312) Multiply accelerometer values by -g on **Windows**
@@ -165,32 +165,32 @@ specific references of old id to new id
 cordova-plugin-device-orientation@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8563](https://issues.apache.org/jira/browse/CB-8563) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** specific references of old id to new id
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Updated **Windows** and **Tizen** specific references of old id to new id
 * [CB-8458](https://issues.apache.org/jira/browse/CB-8458) Fixes false failure of test, when compass hardware is not available
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
-* force async callbacks
+* Force async callbacks
 * Updated plugin to be **Windows** instead of **Windows8**
 * [CB-8614](https://issues.apache.org/jira/browse/CB-8614) **Windows** Fixed `getCurrentHeading` and `watchHeading`
 
 cordova-plugin-dialogs@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated wp and bb specific references of old id to new id
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Updated wp and bb specific references of old id to new id
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * [CB-8367](https://issues.apache.org/jira/browse/CB-8367) **Windows** Add Prompt support
 
 cordova-plugin-file@2.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8689](https://issues.apache.org/jira/browse/CB-8689) Fix `NPE` in `makeEntryForNativeUri` (was affecting file-transfer)
@@ -226,18 +226,18 @@ cordova-plugin-file@2.0.0
 * [CB-7956](https://issues.apache.org/jira/browse/CB-7956) **Browser** Add support
 * [CB-8849](https://issues.apache.org/jira/browse/CB-8849) **WP8** Fixed `ReadAsArrayBuffer` to return `ArrayBuffer` and not Array
 * [CB-8819](https://issues.apache.org/jira/browse/CB-8819) **wp8** Fixed FileReader's `readAsBinaryString`
-* docs: added **Windows** to supported platforms
+* Docs: added **Windows** to supported platforms
 
 cordova-plugin-file-transfer@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8566](https://issues.apache.org/jira/browse/CB-8566) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
+* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) Bumped version of file dependency
 * [CB-8583](https://issues.apache.org/jira/browse/CB-8583) Forces download to overwrite existing target file
 * [CB-8589](https://issues.apache.org/jira/browse/CB-8589) Fixes upload failure when server's response doesn't contain any data
-* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
+* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) Updated dependency, added peer dependency
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Use File proxy to construct valid FileEntry for download success callback
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Removes excess path to native path conversion in download method
 * [CB-8429](https://issues.apache.org/jira/browse/CB-8429) Updated version and `RELEASENOTES.md` for release 0.5.0
@@ -254,7 +254,7 @@ cordova-plugin-file-transfer@1.0.0
 cordova-plugin-geolocation@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8568](https://issues.apache.org/jira/browse/CB-8568) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8681](https://issues.apache.org/jira/browse/CB-8681) Fixed occasional test failures
@@ -262,29 +262,29 @@ cordova-plugin-geolocation@1.0.0
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * Wrong parameter in **Firefox OS** plugin
 * [CB-8443](https://issues.apache.org/jira/browse/CB-8443) Geolocation tests fail on **Windows** due to done is called multiple times
-* docs: added **Windows** to supported platforms
+* Docs: added **Windows** to supported platforms
 
 cordova-plugin-globalization@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **tizen** and **Browser** specific references of old id to new id
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Updated **tizen** and **Browser** specific references of old id to new id
 * [CB-7960](https://issues.apache.org/jira/browse/CB-7960) **Browser** Add support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
-* [CB-8394](https://issues.apache.org/jira/browse/CB-8394) pended unsupported tests for **Windows** and **wp8**
-* separate section in `plugin.xml` and docs for **Windows8** platform
+* [CB-8394](https://issues.apache.org/jira/browse/CB-8394) Pended unsupported tests for **Windows** and **wp8**
+* Separate section in `plugin.xml` and docs for **Windows8** platform
 
 cordova-plugin-inappbrowser@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-4930](https://issues.apache.org/jira/browse/CB-4930) (prefix) InAppBrowser should take into account the status bar
 * Added option to disable/enable zoom controls
-* updated docs, set `hardwareback` default to true
+* Updated docs, set `hardwareback` default to true
 * Add a `hardwareback` option to allow for the hardware back button to go back
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Add a clobber for `cordova.InAppBrowser.open`
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Don't clobber `window.open` - Add new symbol/clobber to access open function (`cordova.InAppBrowser.open`) Change existing tests to use new symbol (i.e. don't rely on plugin clobber of `window.open`) - Add tests to use `window.open` via manual replace with new symbol - Update docs to deprecate plugin clobber of `window.open`
@@ -296,17 +296,17 @@ cordova-plugin-inappbrowser@1.0.0
 * [CB-7689](https://issues.apache.org/jira/browse/CB-7689) Adds `insertCSS` support for **Windows** platform
 * [CB-8635](https://issues.apache.org/jira/browse/CB-8635) Improves UX on **Windows** platform
 * [CB-8661](https://issues.apache.org/jira/browse/CB-8661) Return executed script result on **Windows**
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **WP** and **Browser** specific references of old id to new id
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Updated **WP** and **Browser** specific references of old id to new id
 
 cordova-plugin-media@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
-* [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
+* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) Bumped version of file dependency
+* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) Updated dependency, added peer dependency
+* [CB-8686](https://issues.apache.org/jira/browse/CB-8686) Remove `musicLibrary` capability
 * [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix multiple `done()` calls in media plugin test on devices where audio is not configured
 * [CB-8425](https://issues.apache.org/jira/browse/CB-8425) Media plugin `.ctr`: make src param required as per spec
 * [CB-7962](https://issues.apache.org/jira/browse/CB-7962) Adds **Browser** platform support
@@ -319,11 +319,11 @@ cordova-plugin-media@1.0.0
 
 cordova-plugin-media-capture@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
-* [CB-8687](https://issues.apache.org/jira/browse/CB-8687) consolidate manifest targets
+* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) Bumped version of file dependency
+* [CB-8747](https://issues.apache.org/jira/browse/CB-8747) Updated dependency, added peer dependency
+* [CB-8687](https://issues.apache.org/jira/browse/CB-8687) Consolidate manifest targets
 * [CB-7963](https://issues.apache.org/jira/browse/CB-7963) **Browser** Add support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8571](https://issues.apache.org/jira/browse/CB-8571) Integrate **TravisCI**
@@ -331,7 +331,7 @@ cordova-plugin-media-capture@1.0.0
 
 cordova-plugin-network-information@1.0.0
 
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Fixes typo in `cordova.platformId`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Use `navigator.onLine` as connection information source on **Browser** platform
@@ -342,7 +342,7 @@ cordova-plugin-network-information@1.0.0
 cordova-plugin-splashscreen@2.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8574](https://issues.apache.org/jira/browse/CB-8574) Integrate **TravisCI**
 * [CB-8345](https://issues.apache.org/jira/browse/CB-8345) Make default for splashscreen resource `screen` (which is what template and **CLI** assume it to be)
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
@@ -350,7 +350,7 @@ cordova-plugin-splashscreen@2.0.0
 * [CB-8797](https://issues.apache.org/jira/browse/CB-8797) **iOS** add Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen`
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android** Fix missing import in previous commit
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android** Adds `SplashMaintainAspectRatio` preference
-* docs: added **Windows** to supported platforms
+* Docs: added **Windows** to supported platforms
 * [CB-7964](https://issues.apache.org/jira/browse/CB-7964) **browser** Add support
 * **WP8** respect `SplashScreen` and `SplashScreenDelay` preferences from config file
 * [CB-8397](https://issues.apache.org/jira/browse/CB-8397) **Windows** support showing the **Windows Phone** splashscreen
@@ -358,7 +358,7 @@ cordova-plugin-splashscreen@2.0.0
 cordova-plugin-statusbar@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8575](https://issues.apache.org/jira/browse/CB-8575) Integrate **TravisCI**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme
@@ -368,7 +368,7 @@ cordova-plugin-statusbar@1.0.0
 cordova-plugin-test-framework@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Add a shim for `jasmine.Expectation.addMatchers` being moved in **jasmine 2.2.0**
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Update test framework plugin to use **Jasmine 2.2.0**
 * [CB-8385](https://issues.apache.org/jira/browse/CB-8385) Ensure `plugin-test-framework` trigger tests only once
@@ -376,7 +376,7 @@ cordova-plugin-test-framework@1.0.0
 cordova-plugin-vibration@1.0.0
 
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
+* [CB-8683](https://issues.apache.org/jira/browse/CB-8683) Changed `plugin-id` to `package-name`
 * [CB-8576](https://issues.apache.org/jira/browse/CB-8576) Integrate **TravisCI**
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Reference proxy project instead of compiled `winmd`
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Add `cordova-plugin-vibration` support for **Windows Phone 8.1**

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -8,20 +8,42 @@ categories: announcement release
 tags: plugins announcement releass
 ---
 
-The **Apache Cordova** team is happy to announce a new plugins release that coincides with us moving our core plugins to **[npm]**! We are also encouraging third party plugin developers to start publishing their plugins to npm! To start using plugins from **npm**, developers will have to update their **Cordova CLI** to version 5.0.0 or higher.
+The **Apache Cordova** team is happy to announce a new plugins release that coincides with us moving our core plugins to **[npm]**!
 
-With the move over to **npm**, we have decided to rename our core plugins for improved readability and to better fit within the npm ecosystem. All of our core plugins have changed their IDs from `org.apache.cordova.*` to `cordova-plugin-*`. Developers can now install a plugin with the command `cordova plugin add cordova-plugin-device`. Using the new ID will fetch the plugin directly from **npm**. 
+* We are also encouraging third party plugin developers to start publishing their plugins to npm!
+* To start using plugins from **npm**, developers will have to update their **Cordova CLI** to version **5.0.0** or higher.
 
-Our current **Cordova plugins registry** [CPR] will continue to be operational for at least 6 months (October 15th, 2015) as we help plugin developers with transitioning over to **npm**. This will also allow current **Cordova** developers to upgrade their `CLI` to version 5.0.0 or higher. We will be switching **CPR** to read-only on July 15th, 2015.
+With the move over to **npm**, we have decided to rename our core plugins for improved readability and to better fit within the **npm** ecosystem.
 
-To find plugins on **npm**, search for [ecosystem:cordova]. We are working with **npm** to improve discoverability and will have more to announce later this year. We encourage all third party plugin developers to add `ecosystem:cordova` as a keyword in their plugin's `package.json`.
+* All of our core plugins have changed their IDs from `org.apache.cordova.*` to `cordova-plugin-*`.
+* Developers can now install a plugin with the command `cordova plugin add cordova-plugin-device`.
+Using the new ID will fetch the plugin directly from **npm**.
+
+Our current **Cordova plugins registry** [CPR] will continue to be operational for at least 6 months (`October 15th, 2015`) as we help plugin developers transition over to **npm**.
+This will also allow current **Cordova** developers to upgrade their `CLI` to version **5.0.0** or higher.
+
+* We will be switching [CPR] to read-only on `July 15th, 2015`.
+
+To find plugins on **npm**, search for [ecosystem:cordova].
+We are working with **npm** to improve discoverability and will have more to announce later this year.
+We encourage all third party plugin developers to add `ecosystem:cordova` as a keyword in their plugin's `package.json`.
 
 ## Plugin Authors: Steps to move your plugin to **npm**
-1. **Optional** Decide if you want to change your plugin's `id`. If you decide to change it, update the `id` in `plugin.xml` and update your readme with the new `id`. Next, send a pull request adding your new id and old id to [Cordova Registry Mapper](https://github.com/stevengill/cordova-registry-mapper). We integrate that module into the **Cordova CLI** to warn users to use the new `id` when adding plugins to their projects.
+1. **Optional** Decide if you want to change your plugin's `id`. If you decide to change it,
+    1. Update the `id` in `plugin.xml` and update your readme with the new `id`.
+    1. Send a pull request adding your new id and old id to [Cordova Registry Mapper](https://github.com/stevengill/cordova-registry-mapper).
+    1. We integrate that module into the **Cordova CLI** to warn users to use the new `id` when adding plugins to their projects.
 
-2. Add a `package.json` to your plugins using `plugman createpackagejson [PLUGIN DIRECTORY]`. This will create defaults based on existing values in your `plugin.xml`. It will also automatically add the keyword `ecosystem:cordova` to your newly generated `package.json` file. In addition, a **cordova** key will be added to your `package.json` which we plan to use in future updates of the tooling. View the `package.json` of [cordova-plugin-device] to see an example of what your `package.json` should look like after running `plugman createpackagejson [PLUGIN DIRECTORY] command. Plugins still require a `plugin.xml` to be installed into **Cordova** projects. **Note** To keep things simple, please make sure your `id` in `plugin.xml` is the same as your `package-name` in `package.json`.
+2. Add a `package.json` to your plugins,
+	* **Note** To keep things simple, please make sure your `id` in `plugin.xml` is the same as your `package-name` in `package.json`.
+    * Use `plugman createpackagejson [PLUGIN DIRECTORY]` to create `package.json`.
+        * This will create defaults based on existing values in your `plugin.xml`.
+        * It will also automatically add the keyword `ecosystem:cordova` to your newly generated `package.json` file.
+        * In addition, a **cordova** key will be added to your `package.json` which we plan to use in future updates of the tooling.
+    * View the `package.json` of [cordova-plugin-device](https://github.com/apache/cordova-plugin-device/blob/master/package.json) to see an example of what your `package.json` should look like after running `plugman createpackagejson [PLUGIN DIRECTORY]` command.
+	* Plugins still require a `plugin.xml` to be installed into **Cordova** projects.
 
-3. Publish your plugin to **npm** using the `npm publish [PLUGIN DIRECTORY]`
+3. Publish your plugin to **npm** using the `npm publish [PLUGIN DIRECTORY]`.
 
 ----
 The following plugins were updated today:

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -89,7 +89,6 @@ Plugin changes include:
 
 cordova-plugin-battery-status@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8808](https://issues.apache.org/jira/browse/CB-8808) Fixed tests to pass on **Windows Phone 8.1**
 * [CB-8831](https://issues.apache.org/jira/browse/CB-8831) Adds extra check for available `API` on **Windows**
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
@@ -107,7 +106,6 @@ cordova-plugin-camera@1.0.0
 
 * [CB-8780](https://issues.apache.org/jira/browse/CB-8780) - Display popover using main thread. Fixes popover slowness (closes #81)
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8707](https://issues.apache.org/jira/browse/CB-8707) refactoring **Windows** code to improve readability
 * [CB-8706](https://issues.apache.org/jira/browse/CB-8706) use `filePicker` if `saveToPhotoAlbum` is true
 * [CB-8706](https://issues.apache.org/jira/browse/CB-8706) remove unnecessary capabilities from `xml`
@@ -127,7 +125,6 @@ cordova-plugin-camera@1.0.0
 
 cordova-plugin-console@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
@@ -138,7 +135,6 @@ cordova-plugin-console@1.0.0
 
 cordova-plugin-contacts@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **wp** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -152,7 +148,6 @@ cordova-plugin-contacts@1.0.0
 
 cordova-plugin-device@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
@@ -163,7 +158,6 @@ cordova-plugin-device@1.0.0
 
 cordova-plugin-device-motion@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -177,7 +171,6 @@ cordova-plugin-device-motion@1.0.0
 
 cordova-plugin-device-orientation@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -194,7 +187,6 @@ cordova-plugin-device-orientation@1.0.0
 
 cordova-plugin-dialogs@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated wp and bb specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
@@ -209,7 +201,6 @@ cordova-plugin-file@2.0.0
 
 * [CB-8849](https://issues.apache.org/jira/browse/CB-8849) Fixed `ReadAsArrayBuffer` to return `ArrayBuffer` and not Array on **WP8**
 * [CB-8819](https://issues.apache.org/jira/browse/CB-8819) Fixed FileReader's `readAsBinaryString` on **wp8**
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) `Android`: Fix broken unit tests from plugin rename
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -251,7 +242,6 @@ cordova-plugin-file@2.0.0
 cordova-plugin-file-transfer@1.0.0
 
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8641](https://issues.apache.org/jira/browse/CB-8641) Fixed tests to pass on **Windows** and **wp8**
 * [CB-8583](https://issues.apache.org/jira/browse/CB-8583) Forces download to overwrite existing target file
 * [CB-8589](https://issues.apache.org/jira/browse/CB-8589) Fixes upload failure when server's response doesn't contain any data
@@ -276,7 +266,6 @@ cordova-plugin-file-transfer@1.0.0
 
 cordova-plugin-geolocation@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
@@ -291,7 +280,6 @@ cordova-plugin-geolocation@1.0.0
 
 cordova-plugin-globalization@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **tizen** and **Browser** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -305,7 +293,6 @@ cordova-plugin-globalization@1.0.0
 
 cordova-plugin-inappbrowser@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-7689](https://issues.apache.org/jira/browse/CB-7689) Adds `insertCSS` support for **Windows** platform
 * [CB-4930](https://issues.apache.org/jira/browse/CB-4930) - (prefix) InAppBrowser should take into account the status bar
 * [CB-8635](https://issues.apache.org/jira/browse/CB-8635) Improves UX on **Windows** platform
@@ -331,7 +318,6 @@ cordova-plugin-media@1.0.0
 
 * [CB-8793](https://issues.apache.org/jira/browse/CB-8793) Fixed tests to pass on **wp8** and **Windows**
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8779](https://issues.apache.org/jira/browse/CB-8779) Fixed media status reporting on **wp8**
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
@@ -351,7 +337,6 @@ cordova-plugin-media@1.0.0
 cordova-plugin-media-capture@1.0.0
 
 * [CB-8746](https://issues.apache.org/jira/browse/CB-8746) bumped version of file dependency
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
@@ -364,7 +349,6 @@ cordova-plugin-media-capture@1.0.0
 
 cordova-plugin-network-information@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Fixes typo in `cordova.platformId`
@@ -376,7 +360,6 @@ cordova-plugin-network-information@1.0.0
 
 cordova-plugin-splashscreen@2.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8797](https://issues.apache.org/jira/browse/CB-8797) - Splashscreen preferences `FadeSplashScreenDuration` and `FadeSplashScreen` (**iOS**) are missing
 * [CB-8836](https://issues.apache.org/jira/browse/CB-8836) - Crashes after animating `splashscreen`
 * [CB-8753](https://issues.apache.org/jira/browse/CB-8753) **Android**: Fix missing import in previous commit
@@ -395,7 +378,6 @@ cordova-plugin-splashscreen@2.0.0
 
 cordova-plugin-statusbar@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
@@ -407,7 +389,6 @@ cordova-plugin-statusbar@1.0.0
 
 cordova-plugin-test-framework@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Add a shim for `jasmine.Expectation.addMatchers` being moved in **jasmine 2.2.0**
 * [CB-8528](https://issues.apache.org/jira/browse/CB-8528) Update test framework plugin to use **Jasmine 2.2.0** (close #11)
@@ -416,7 +397,6 @@ cordova-plugin-test-framework@1.0.0
 
 cordova-plugin-vibration@1.0.0
 
-* [CB-8746](https://issues.apache.org/jira/browse/CB-8746) gave plugin major version bump
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Reference proxy project instead of compiled `winmd`

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -94,7 +94,7 @@ cordova-plugin-battery-status@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * add **Android**+**FireOS** warning to tell devs that prolonged use will drain the battery
 * [CB-7971](https://issues.apache.org/jira/browse/CB-7971) Add `cordova-plugin-battery-status` support for **Windows Phone 8.1**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWithWebView` method
@@ -118,7 +118,7 @@ cordova-plugin-camera@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8351](https://issues.apache.org/jira/browse/CB-8351) Fix custom implementation of `integerValueForKey` (close #79)
-* Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install paramedic
+* Fix `cordova-paramedic` path change, build with `TRAVIS_BUILD_DIR`, use **npm** to install **paramedic**
 * docs: added **Windows** to supported platforms
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
@@ -127,9 +127,9 @@ cordova-plugin-console@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install ***paramedic** by **npm**
 * docs: renamed **Windows8** to **Windows**
-* [CB-8560](https://issues.apache.org/jira/browse/CB-8560) Integrate `TravisCI`
+* [CB-8560](https://issues.apache.org/jira/browse/CB-8560) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8362](https://issues.apache.org/jira/browse/CB-8362) Add **Windows** platform section to Console plugin
 
@@ -138,11 +138,11 @@ cordova-plugin-contacts@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **wp** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * [CB-8604](https://issues.apache.org/jira/browse/CB-8604) Pended unsupported test for **wp8**, updated documentation
-* [CB-8561](https://issues.apache.org/jira/browse/CB-8561) Integrate `TravisCI`
+* [CB-8561](https://issues.apache.org/jira/browse/CB-8561) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8395](https://issues.apache.org/jira/browse/CB-8395) marked unsupported tests pending on **wp8**
 
@@ -150,10 +150,10 @@ cordova-plugin-device@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * remove defunct **windows8** version
 * add travis badge
-* Add cross-plugin ios paramedic test running for `TravisCI`
+* Add cross-plugin ios paramedic test running for **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-device-motion@1.0.0
@@ -161,9 +161,9 @@ cordova-plugin-device-motion@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **Tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8312](https://issues.apache.org/jira/browse/CB-8312) Multiply accelerometer values by -g on **Windows**
-* [CB-8562](https://issues.apache.org/jira/browse/CB-8562) Integrate `TravisCI`
+* [CB-8562](https://issues.apache.org/jira/browse/CB-8562) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended recently added spec.12 if accelerometer doesn't exist on the device
 * [CB-8096](https://issues.apache.org/jira/browse/CB-8096) Pended auto tests if accelerometer doesn't exist on the device
@@ -174,14 +174,14 @@ cordova-plugin-device-orientation@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **Windows** and **tizen** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) Updated Readme
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * force async callbacks
 * Updated plugin to be **Windows** instead of **Windows8**
 * [CB-8614](https://issues.apache.org/jira/browse/CB-8614) Fixed `getCurrentHeading` and `watchHeading` on **Windows** platform
-* [CB-8563](https://issues.apache.org/jira/browse/CB-8563) Integrate `TravisCI`
+* [CB-8563](https://issues.apache.org/jira/browse/CB-8563) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8458](https://issues.apache.org/jira/browse/CB-8458) Fixes false failure of test, when compass hardware is not available
 
@@ -191,9 +191,9 @@ cordova-plugin-dialogs@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
-* [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate `TravisCI`
+* [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8367](https://issues.apache.org/jira/browse/CB-8367) [org.apache.cordova.dialogs] Add Prompt support on **Windows**
 
@@ -204,7 +204,7 @@ cordova-plugin-file@2.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) **Android** Fix broken unit tests from plugin rename
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * docs: added **Windows** to supported platforms
 * [CB-8699](https://issues.apache.org/jira/browse/CB-8699) [CB-6428](https://issues.apache.org/jira/browse/CB-6428) Fix uncompressed assets being copied as zero length files
 * [CB-6428](https://issues.apache.org/jira/browse/CB-6428) **Android**: Fix assets `FileEntry` having size of -1
@@ -232,7 +232,7 @@ cordova-plugin-file@2.0.0
 * **Android**: Delete invalid `JavaDoc` (lint errors)
 * **Android**: Use `CordovaResourceAp`i rather than `FileHelper`
 * [CB-8032](https://issues.apache.org/jira/browse/CB-8032) File Plugin - Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:` (closes #96)
-* [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate `TravisCI`
+* [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-7956](https://issues.apache.org/jira/browse/CB-7956) Add `cordova-plugin-file` support for **Browser** platform
 * [CB-8423](https://issues.apache.org/jira/browse/CB-8423) Corrected usage of `done()` in async tests
@@ -248,10 +248,10 @@ cordova-plugin-file-transfer@1.0.0
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8654](https://issues.apache.org/jira/browse/CB-8654) Note **WP8** download requests caching in docs
 * [CB-8590](https://issues.apache.org/jira/browse/CB-8590) **Windows** Fixed `download.onprogress.lengthComputable`
-* [CB-8566](https://issues.apache.org/jira/browse/CB-8566) Integrate `TravisCI`
+* [CB-8566](https://issues.apache.org/jira/browse/CB-8566) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8495](https://issues.apache.org/jira/browse/CB-8495) Fixed **wp8** and **wp8.1** test failures
 * [CB-7957](https://issues.apache.org/jira/browse/CB-7957) Adds support for `browser` platform
@@ -268,13 +268,13 @@ cordova-plugin-geolocation@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8681](https://issues.apache.org/jira/browse/CB-8681) Fixed occasional test failures
 * docs: added **Windows** to supported platforms
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
 * Wrong parameter in **Firefox OS** plugin
-* [CB-8568](https://issues.apache.org/jira/browse/CB-8568) Integrate `TravisCI`
+* [CB-8568](https://issues.apache.org/jira/browse/CB-8568) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8443](https://issues.apache.org/jira/browse/CB-8443) Geolocation tests fail on **Windows** due to done is called multiple times
 
@@ -283,11 +283,11 @@ cordova-plugin-globalization@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **tizen** and **Browser** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * separate section in `plugin.xml` and docs for **Windows8** platform
 * [CB-7960](https://issues.apache.org/jira/browse/CB-7960) Add `cordova-plugin-globalization` support for **Browser** platform
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate `TravisCI`
+* [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8394](https://issues.apache.org/jira/browse/CB-8394) pended unsupported tests for **Windows** and **wp8**
 
@@ -300,7 +300,7 @@ cordova-plugin-inappbrowser@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) updated **WP** and **Browser** specific references of old id to new id
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8432](https://issues.apache.org/jira/browse/CB-8432) Correct styles for **Browser** wrapper to display it correctly on some pages
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x (closes #93)
 * [CB-7961](https://issues.apache.org/jira/browse/CB-7961) Add `cordova-plugin-inappbrowser` support for **Browser** platform
@@ -308,7 +308,7 @@ cordova-plugin-inappbrowser@1.0.0
 * Added option to disable/enable zoom controls
 * updated docs, set `hardwareback` default to true
 * Add a `hardwareback` option to allow for the hardware back button to go back
-* [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate `TravisCI`
+* [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * Keep external **Android** pages in a single tab. (close #61)
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Add a clobber for `cordova.InAppBrowser.open` (close #80)
@@ -323,11 +323,11 @@ cordova-plugin-media@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8541](https://issues.apache.org/jira/browse/CB-8541) Adds information about available recording formats on **Windows**
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
 * [CB-7962](https://issues.apache.org/jira/browse/CB-7962) Adds **Browser** platform support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of deprecated headers
-* [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate `TravisCI`
+* [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix tests on **Windows** if no audio playback hardware is available
 * [CB-8428](https://issues.apache.org/jira/browse/CB-8428) Fix multiple `done()` calls in media plugin test on devices where audio is not configured
@@ -340,11 +340,11 @@ cordova-plugin-media-capture@1.0.0
 * [CB-8747](https://issues.apache.org/jira/browse/CB-8747) updated dependency, added peer dependency
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8687](https://issues.apache.org/jira/browse/CB-8687) consolidate manifest targets
 * [CB-7963](https://issues.apache.org/jira/browse/CB-7963) Adds support for **Browser** platform
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8571](https://issues.apache.org/jira/browse/CB-8571) Integrate `TravisCI`
+* [CB-8571](https://issues.apache.org/jira/browse/CB-8571) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-network-information@1.0.0
@@ -352,10 +352,10 @@ cordova-plugin-network-information@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Fixes typo in `cordova.platformId`
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8185](https://issues.apache.org/jira/browse/CB-8185) Use `navigator.onLine` as connection information source on **Browser** platform
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS**: 4.0.x Compatibility: Remove use of `initWebView` method
-* [CB-8573](https://issues.apache.org/jira/browse/CB-8573) Integrate `TravisCI`
+* [CB-8573](https://issues.apache.org/jira/browse/CB-8573) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-splashscreen@2.0.0
@@ -368,11 +368,11 @@ cordova-plugin-splashscreen@2.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * [CB-8345](https://issues.apache.org/jira/browse/CB-8345) Make default for splashscreen resource `screen` (which is what template and **CLI** assume it to be)
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * docs: added **Windows** to supported platforms
 * [CB-7964](https://issues.apache.org/jira/browse/CB-7964) Add `cordova-plugin-splashscreen` support for **browser** platform
 * Extend **WP8** Splash Screen to respect `SplashScreen` and `SplashScreenDelay` preferences from config file
-* [CB-8574](https://issues.apache.org/jira/browse/CB-8574) Integrate `TravisCI`
+* [CB-8574](https://issues.apache.org/jira/browse/CB-8574) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 * [CB-8397](https://issues.apache.org/jira/browse/CB-8397) Add support to **Windows** for showing the **Windows Phone** splashscreen
 
@@ -380,11 +380,11 @@ cordova-plugin-statusbar@1.0.0
 
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
-* Use `TRAVIS_BUILD_DIR`, install paramedic by **npm**
+* Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * Use `StatusBarBackgroundColor` instead of `AndroidStatusBarBackgroundColor`, and added a quirk to the readme
 * Add support for `StatusBar.backgroundColorByHexString` (and `StatusBar.backgroundColorByName`) on **Android 5** and up
 * Allow setting the `statusbar backgroundcolor` on **Android**
-* [CB-8575](https://issues.apache.org/jira/browse/CB-8575) Integrate `TravisCI`
+* [CB-8575](https://issues.apache.org/jira/browse/CB-8575) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 cordova-plugin-test-framework@1.0.0
@@ -401,7 +401,7 @@ cordova-plugin-vibration@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) properly updated translated docs to use new id
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Reference proxy project instead of compiled `winmd`
 * [CB-7970](https://issues.apache.org/jira/browse/CB-7970) Add `cordova-plugin-vibration` support for **Windows Phone 8.1**
-* [CB-8576](https://issues.apache.org/jira/browse/CB-8576) Integrate `TravisCI`
+* [CB-8576](https://issues.apache.org/jira/browse/CB-8576) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
 
 [npm]: https://www.npmjs.org/

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -294,7 +294,7 @@ cordova-plugin-inappbrowser@1.0.0
 * Add a `hardwareback` option to allow for the hardware back button to go back
 * [CB-8570](https://issues.apache.org/jira/browse/CB-8570) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* Keep external **Android** pages in a single tab.
+* Keep external **Android** pages in a single tab
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Add a clobber for `cordova.InAppBrowser.open`
 * [CB-8444](https://issues.apache.org/jira/browse/CB-8444) Don't clobber `window.open` - Add new symbol/clobber to access open function (`cordova.InAppBrowser.open`) Change existing tests to use new symbol (i.e. don't rely on plugin clobber of `window.open`) - Add tests to use `window.open` via manual replace with new symbol - Update docs to deprecate plugin clobber of `window.open`
 

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -195,7 +195,7 @@ cordova-plugin-dialogs@1.0.0
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * [CB-8565](https://issues.apache.org/jira/browse/CB-8565) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-8367](https://issues.apache.org/jira/browse/CB-8367) [org.apache.cordova.dialogs] Add Prompt support on **Windows**
+* [CB-8367](https://issues.apache.org/jira/browse/CB-8367) Add Prompt support on **Windows**
 
 cordova-plugin-file@2.0.0
 
@@ -231,10 +231,10 @@ cordova-plugin-file@2.0.0
 * **Android**: Use Uri.parse rather than manual parsing in resolveLocalFileSystemURI
 * **Android**: Delete invalid `JavaDoc` (lint errors)
 * **Android**: Use `CordovaResourceAp`i rather than `FileHelper`
-* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) File Plugin - Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:`
+* [CB-8032](https://issues.apache.org/jira/browse/CB-8032) Add `nativeURL` external method support for `CDVFileSystem->makeEntryForPath:isDirectory:`
 * [CB-8567](https://issues.apache.org/jira/browse/CB-8567) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
-* [CB-7956](https://issues.apache.org/jira/browse/CB-7956) Add `cordova-plugin-file` support for **Browser** platform
+* [CB-7956](https://issues.apache.org/jira/browse/CB-7956) **Browser** Add support
 * [CB-8423](https://issues.apache.org/jira/browse/CB-8423) Corrected usage of `done()` in async tests
 * [CB-8459](https://issues.apache.org/jira/browse/CB-8459) Fixes spec 111 failure due to incorrect relative paths handling
 * Added `nativeURL` property to `FileEntry`, implemented `readAsArrayBuffer` and `readAsBinaryString`
@@ -285,7 +285,7 @@ cordova-plugin-globalization@1.0.0
 * [CB-8653](https://issues.apache.org/jira/browse/CB-8653) updated translated docs to use new id
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * separate section in `plugin.xml` and docs for **Windows8** platform
-* [CB-7960](https://issues.apache.org/jira/browse/CB-7960) Add `cordova-plugin-globalization` support for **Browser** platform
+* [CB-7960](https://issues.apache.org/jira/browse/CB-7960) **Browser** Add support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8569](https://issues.apache.org/jira/browse/CB-8569) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -303,7 +303,7 @@ cordova-plugin-inappbrowser@1.0.0
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8432](https://issues.apache.org/jira/browse/CB-8432) Correct styles for **Browser** wrapper to display it correctly on some pages
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) Update `InAppBrowser` to support both **cordova-ios** 4.0.x and 3.x
-* [CB-7961](https://issues.apache.org/jira/browse/CB-7961) Add `cordova-plugin-inappbrowser` support for **Browser** platform
+* [CB-7961](https://issues.apache.org/jira/browse/CB-7961) **Browser** Add support
 * Update docs for **Android** `zoom=no` option
 * Added option to disable/enable zoom controls
 * updated docs, set `hardwareback` default to true

--- a/2015-04-15-plugins-release-and-move-to-npm.md
+++ b/2015-04-15-plugins-release-and-move-to-npm.md
@@ -245,7 +245,7 @@ cordova-plugin-file-transfer@1.0.0
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Use File proxy to construct valid FileEntry for download success callback
 * [CB-8407](https://issues.apache.org/jira/browse/CB-8407) Removes excess path to native path conversion in download method
 * [CB-8429](https://issues.apache.org/jira/browse/CB-8429) Updated version and `RELEASENOTES.md` for release 0.5.0
-* [CB-7957](https://issues.apache.org/jira/browse/CB-7957) Adds support for **Browser** platform
+* [CB-7957](https://issues.apache.org/jira/browse/CB-7957) **Browser** Add support
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Fixes JSHint and formatting issues
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Updates tests and documentation
 * [CB-8095](https://issues.apache.org/jira/browse/CB-8095) Rewrite upload method to support progress events properly
@@ -308,7 +308,7 @@ cordova-plugin-media@1.0.0
 * [CB-8541](https://issues.apache.org/jira/browse/CB-8541) Adds information about available recording formats on **Windows**
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8686](https://issues.apache.org/jira/browse/CB-8686) remove `musicLibrary` capability
-* [CB-7962](https://issues.apache.org/jira/browse/CB-7962) Adds **Browser** platform support
+* [CB-7962](https://issues.apache.org/jira/browse/CB-7962) **Browser** Add support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of deprecated headers
 * [CB-8572](https://issues.apache.org/jira/browse/CB-8572) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file
@@ -324,7 +324,7 @@ cordova-plugin-media-capture@1.0.0
 * [CB-8683](https://issues.apache.org/jira/browse/CB-8683) changed `plugin-id` to `package-name`
 * Use `TRAVIS_BUILD_DIR`, install **paramedic** by **npm**
 * [CB-8687](https://issues.apache.org/jira/browse/CB-8687) consolidate manifest targets
-* [CB-7963](https://issues.apache.org/jira/browse/CB-7963) Adds support for **Browser** platform
+* [CB-7963](https://issues.apache.org/jira/browse/CB-7963) **Browser** Add support
 * [CB-8659](https://issues.apache.org/jira/browse/CB-8659) **iOS 4.0.x** Compatibility: Remove use of `initWebView` method
 * [CB-8571](https://issues.apache.org/jira/browse/CB-8571) Integrate **TravisCI**
 * [CB-8538](https://issues.apache.org/jira/browse/CB-8538) Added `package.json` file


### PR DESCRIPTION
Someone is welcome to fold these...

* uppercase first letter of bullets
* reorder package.json/plugin.xml/travis/.../platforms
* drop trailing periods
* list platform at beginning
* drop duplicate
* drop updated translated docs to use new id
* drop odd doubled bug reference, hopefully leaving the right one...
* drop redundant plugin name from plugin section
* drop (close..#..)
* include version w/ iOS in **
* use ** for paramedic + TravisCI
* use ** for platforms
* markdown fixes
* drop gave plugin major version bump
* use markdown autonumbering
* split paragraphs at sentences and use bullets
* use named links
* use named links
* add named links
* markdown sections
* list plugins on individual lines (a77ad61 equivalent to half of #37)

They're split because reviewing them combined is impossible (it looks like a complete rewrite), plus, merging w/ others (e.g. @tony--) would be disastrous if they weren't.